### PR TITLE
Release 0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ dependency-update policy.
 
 ## [Unreleased]
 
+## [0.3.2] - 2026-08-04
+
+### Changed
+
+- Updated `@openai/codex-sdk` from `0.145.0` to `0.146.0` and
+  `@anthropic-ai/claude-agent-sdk` from `0.3.218` to `0.3.220`. Re-qualified
+  both native adapters with `neal compat`; no behavior change.
+
 ## [0.3.1] - 2026-07-27
 
 Initial release from the reset public repository.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@navels/neal",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "A source-first multi-agent CLI for planning, executing, reviewing, and resuming scoped code changes.",
   "license": "MIT",
   "publishConfig": {


### PR DESCRIPTION
## Summary

- Prepare the `0.3.2` patch release after updating the native agentic SDKs.

## Changes

- Bump `@navels/neal` from `0.3.1` to `0.3.2`.
- Add the `0.3.2` changelog entry.
- Record successful compatibility qualification with no behavior change.