### PR TITLE
Prepare 0.3.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ dependency-update policy.
 
 ## [Unreleased]
 
+## [0.3.3] - 2026-08-14
+
+### Changed
+
+- Updated `@openai/codex-sdk` from `0.146.0` to `0.147.0` and
+  `@anthropic-ai/claude-agent-sdk` from `0.3.220` to `0.3.227`. Re-qualified
+  both native adapters with `neal compat`; no behavior change.
+- Updated `ai` from `7.0.31` to `7.0.58` and `@ai-sdk/openai-compatible` from
+  `3.0.12` to `3.0.27`.
+
 ## [0.3.2] - 2026-08-04
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@navels/neal",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "A source-first multi-agent CLI for planning, executing, reviewing, and resuming scoped code changes.",
   "license": "MIT",
   "publishConfig": {


### PR DESCRIPTION
## Summary

Release prep for 0.3.3, a patch release covering the qualified native SDK bumps and the weekly runtime dependency updates.

## Changes

- Bump `package.json.version` to 0.3.3
- Add the 0.3.3 changelog section: `@openai/codex-sdk` 0.146.0 -> 0.147.0, `@anthropic-ai/claude-agent-sdk` 0.3.220 -> 0.3.227 (re-qualified via `scripts/qualify-sdk.sh`), `ai` 7.0.31 -> 7.0.58, `@ai-sdk/openai-compatible` 3.0.12 -> 3.0.27

All release gates pass locally: `validate:release` (dry run), typecheck, lint, test (1696 pass), build, `verify-package`.