### PR TITLE
Let structured-JSON repair see the first control block and accept a lone json fence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ dependency-update policy.
 
 ### Fixed
 
+- Structured-JSON repair could not recover a payload that was already valid.
+  When a response had two `neal-json` blocks, the repair prompt got no JSON at
+  all; the original response was cut at 12,000 chars, which truncated a
+  nine-finding review payload mid-object; and a repair that answered with one
+  ```json fence was rejected for the fence label alone. The repair prompt now
+  receives the first block's JSON, the original-response bound is 60,000 chars,
+  and a lone fenced JSON object is accepted with the same tolerance as a raw
+  JSON object. (#11)
 - `neal review` printed `claude --resume <id>` for every recorded session, even
   when the reviewer was `openai-codex` and the id was a Codex thread id that
   `claude --resume` cannot open. Rounds now record which provider owns each

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -342,9 +342,13 @@ neal's shared `neal-json-block-v1` runtime appends provider-neutral transport
 instructions requiring optional useful prose followed by exactly one final
 fenced `neal-json` JSON block. It then extracts, parses, validates, and repairs
 that control object with the caller-supplied schema label, schema, validator,
-and repair limit. Raw whole-response JSON objects are accepted only as a
-compatibility tolerance for older mocks and pre-migration paths. The prompt
-contract remains prose plus one final `neal-json` block. State-facing
+and repair limit. Raw whole-response JSON objects, and a single fenced JSON
+object (any fence label) that is the whole response, are accepted only as a
+compatibility tolerance for older mocks, pre-migration paths, and repair turns
+that render the payload as a ```json fence. The prompt contract remains prose
+plus one final `neal-json` block. When a response carries more than one
+`neal-json` block it is still rejected, but the first block's JSON is passed
+to the repair prompt so repair works from the real payload. State-facing
 `structured_output_received` telemetry is emitted only after neal validation
 succeeds.
 

--- a/src/neal/agents/structured-json.ts
+++ b/src/neal/agents/structured-json.ts
@@ -135,7 +135,17 @@ type NealJsonBlock = {
 };
 
 const SUMMARY_MAX_LENGTH = 800;
-const ORIGINAL_RESPONSE_MAX_LENGTH = 12000;
+// Bound on the original response echoed into a repair prompt. A real
+// `neal review` payload with nine findings ended at ~14,400 chars, so the old
+// 12,000 cap handed the repair model a JSON object cut off mid-finding and it
+// invented a "truncated" warning and dropped a finding (#11). 60,000 leaves
+// about 4x headroom over that payload while still bounding a runaway response.
+const ORIGINAL_RESPONSE_MAX_LENGTH = 60000;
+// Any fenced block, with or without a language label, that is the only
+// non-whitespace content of a response. Accepted with raw-JSON tolerance
+// because repair turns render "raw whole-response JSON object" as a ```json
+// fence and that payload is otherwise complete.
+const GENERIC_OPENING_FENCE_PATTERN = /^[ \t]*```[ \t]*[A-Za-z0-9_-]*[ \t]*$/;
 const NEAL_JSON_OPENING_FENCE_PATTERN = /^[ \t]*```[ \t]*neal-json[ \t]*$/;
 const CLOSING_FENCE_PATTERN = /^[ \t]*```[ \t]*$/;
 
@@ -213,12 +223,16 @@ export function extractStructuredJsonPayload(assistantText: string): StructuredJ
   const blocks = findNealJsonBlocks(assistantText);
 
   if (blocks.length > 1) {
+    // Still a failure, but hand the first block's JSON to the repair prompt so
+    // the repair model works from the real payload instead of a truncated
+    // transcript. The first block is the one the prompt contract asked for;
+    // later blocks are usually echoes or rewrites of it (#11).
     return {
       ok: false,
       errorKind: 'multiple_control_blocks',
       errorSummary: `Expected exactly one final neal-json control block, but found ${blocks.length}.`,
       prose: assistantText.trim(),
-      rawJson: null,
+      rawJson: blocks[0].rawJson,
     };
   }
 
@@ -245,6 +259,15 @@ export function extractStructuredJsonPayload(assistantText: string): StructuredJ
   }
 
   const trimmed = assistantText.trim();
+  const loneFencedJson = extractLoneFencedJson(trimmed);
+  if (loneFencedJson !== null) {
+    return parseExtractedJson({
+      source: 'raw-json',
+      prose: '',
+      rawJson: loneFencedJson,
+      malformedSummaryPrefix: 'The fenced JSON response was invalid',
+    });
+  }
   if (!looksLikeRawJsonObject(trimmed)) {
     return {
       ok: false,
@@ -792,6 +815,25 @@ function parseExtractedJson(args: {
 
 function looksLikeRawJsonObject(trimmed: string) {
   return trimmed.startsWith('{') || trimmed.startsWith('[');
+}
+
+// Returns the inner text when the whole (trimmed) response is exactly one
+// fenced block: an opening fence line, content with no fence lines inside, and
+// a closing fence as the last line. Null otherwise, including when anything
+// sits outside the fence; that case keeps its existing error.
+function extractLoneFencedJson(trimmed: string): string | null {
+  const lines = trimmed.split(/\r?\n/);
+  if (lines.length < 3) {
+    return null;
+  }
+  if (!GENERIC_OPENING_FENCE_PATTERN.test(lines[0]) || !CLOSING_FENCE_PATTERN.test(lines[lines.length - 1])) {
+    return null;
+  }
+  const inner = lines.slice(1, -1);
+  if (inner.some((line) => /^[ \t]*```/.test(line))) {
+    return null;
+  }
+  return inner.join('\n');
 }
 
 function isJsonObject(value: unknown): value is Record<string, unknown> {

--- a/test/structured-json.test.ts
+++ b/test/structured-json.test.ts
@@ -156,6 +156,83 @@ test('rejects multiple neal-json control blocks', () => {
   }
 });
 
+test('multiple neal-json control blocks hand the first block to the repair prompt', () => {
+  const firstJson = reviewerJson(validReviewerPayload({ summary: 'First block.' }));
+  const secondJson = reviewerJson(validReviewerPayload({ summary: 'Second block (a rewrite of the first).' }));
+  const response = `Prose.\n\n\`\`\`neal-json\n${firstJson}\n\`\`\`\n\nRewrite follows.\n\n\`\`\`neal-json\n${secondJson}\n\`\`\``;
+  const result = extractStructuredJsonPayload(response);
+
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.equal(result.errorKind, 'multiple_control_blocks');
+    assert.equal(result.rawJson, firstJson);
+  }
+
+  const prompt = buildStructuredJsonRepairPrompt({
+    originalAssistantText: response,
+    invalidJson: result.ok ? null : result.rawJson,
+    extractionErrorSummary: result.ok ? null : result.errorSummary,
+    validationErrorSummary: null,
+    schemaLabel: 'reviewer_payload',
+    schema: buildReviewerSchema(),
+    attemptNumber: 1,
+    attemptLimit: 2,
+  });
+  assert.match(prompt, /Extracted invalid JSON, if any:\n```json\n/);
+  assert.ok(prompt.includes(firstJson), 'repair prompt should carry the first block JSON');
+  assert.doesNotMatch(prompt, /No JSON payload was extracted/);
+});
+
+test('repair prompt keeps a review-sized original response intact and still bounds a runaway one', () => {
+  const build = (originalAssistantText: string) =>
+    buildStructuredJsonRepairPrompt({
+      originalAssistantText,
+      invalidJson: null,
+      extractionErrorSummary: 'x',
+      validationErrorSummary: null,
+      schemaLabel: 'reviewer_payload',
+      schema: buildReviewerSchema(),
+      attemptNumber: 1,
+      attemptLimit: 2,
+    });
+
+  // A nine-finding review payload ended at ~14,400 chars; 30,000 must survive whole.
+  const reviewSized = 'r'.repeat(30000);
+  assert.ok(build(reviewSized).includes(reviewSized));
+  assert.doesNotMatch(build(reviewSized), /\[truncated/);
+
+  const runaway = 'r'.repeat(70000);
+  assert.match(build(runaway), /\[truncated 10000 byte\(s\)\]/);
+});
+
+test('accepts a lone fenced JSON object with the raw-JSON tolerance', () => {
+  for (const label of ['json', '']) {
+    const response = `\`\`\`${label}\n${reviewerJson()}\n\`\`\``;
+    const result = validateStructuredJsonPayload(response, validateReviewerPayload);
+
+    if (!result.ok) {
+      assert.fail(`${label || '(no label)'} fence: ${result.errorSummary}`);
+    }
+    assert.equal(result.source, 'raw-json');
+    assert.equal(result.prose, '');
+    assert.deepEqual(result.structured, validReviewerPayload());
+  }
+});
+
+test('a fenced JSON object with anything outside the fence is still rejected', () => {
+  const trailing = extractStructuredJsonPayload(`\`\`\`json\n${reviewerJson()}\n\`\`\`\n\nTrailing prose.`);
+  assert.equal(trailing.ok, false);
+  if (!trailing.ok) {
+    assert.equal(trailing.errorKind, 'missing_control_block');
+  }
+
+  const leading = extractStructuredJsonPayload(`Leading prose.\n\n\`\`\`json\n${reviewerJson()}\n\`\`\``);
+  assert.equal(leading.ok, false);
+  if (!leading.ok) {
+    assert.equal(leading.errorKind, 'missing_control_block');
+  }
+});
+
 test('rejects a non-final neal-json control block', () => {
   const result = extractStructuredJsonPayload(`${reviewerBlock()}\n\nTrailing prose is not allowed.`);
 


### PR DESCRIPTION
## Summary

Structured-JSON repair couldn't recover a payload that was already valid: a two-block response gave the repair prompt no JSON, the 12,000-char echo cut a nine-finding review mid-object, and a repair answering with one ```json fence was rejected on the fence label.

## Changes

- `multiple_control_blocks` failures pass the first block's JSON to the repair prompt (still a failure, no auto-pick)
- original-response bound in the repair prompt raised from 12,000 to 60,000 chars
- a lone fenced JSON object (any label) is accepted with the existing raw-JSON tolerance; anything outside the fence still fails
- `docs/providers.md` tolerance paragraph updated; CHANGELOG entry
- 4 new tests in `test/structured-json.test.ts`

Closes #11
