### PR TITLE
Show the scope reviewer earlier-scope diffs for files the current scope touches again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,15 @@ dependency-update policy.
   sentences, everyday words, no undefined shorthand, with exact paths,
   identifiers, numbers, and SHAs preserved. The reviewer treats wording that
   breaks those rules as a revise reason.
+- The scope reviewer now sees earlier accepted scopes' per-file diffs for any
+  file the current scope diff touches again, under "Earlier-scope changes to
+  files in this diff", and its doctrine says that weakening or removing a
+  test, assertion, or check an earlier scope introduced is a blocking finding
+  unless the plan calls for it. The reviewer continuity packet also lists each
+  completed scope's changed files. Before this, the reviewer's only record of
+  an earlier scope was the coder's summary, so a later scope could meet its own
+  criteria by undoing an earlier one without the reviewer noticing. `scope_reviewer`
+  prompt spec bumped to version 3. (#10)
 
 ## [0.3.3] - 2026-08-14
 

--- a/docs/prompt-specs.md
+++ b/docs/prompt-specs.md
@@ -56,7 +56,7 @@ All schema targets are `structured_json` with provider surface
 | `plan_author` | `buildPlanningPrompt`, `buildCoderPlanResponsePrompt` (`reviewMode=plan`, `reviewMode=derived-plan`) | `runCoderPlanRound`, `runCoderPlanResponseRound` | Primary planning: `buildCoderPlanSchema` / `validateCoderPlanPayload`. Response rounds: `buildCoderPlanResponseSchema` / `validateCoderPlanResponsePayload`. | Primary planning routes new/resumed structured sessions by persisted `plannerSessionProtocol`. Legacy marker parsing is retained only for active `legacy_marker_v1` sessions. |
 | `plan_reviewer` | `buildPlanReviewerPrompt` (`mode=plan`, `mode=derived-plan`) | `runPlanReviewerRound` | `buildPlanReviewerSchema` / `PlanReviewerPayload` | Execution-shape confirmation is part of the contract. Reviews material approach, scope, sequencing, and verification defects without turning the plan into an implementation inventory. |
 | `scope_coder` | `buildScopePrompt`, `buildCoderResponsePrompt` | `runCoderScopeRound`, `runCoderResponseRound` | Primary execution: `buildCoderScopeSchema` / `validateCoderScopePayload`. Response rounds: `buildCoderResponseSchema` / `validateCoderResponsePayload`. | Primary execution routes new/resumed structured sessions by persisted `coderSessionProtocol`. Legacy marker and progress-payload parsing is retained only for active `legacy_marker_v1` sessions. Also carries an `adjacent`-status blocked-recovery `response` variant (see below). |
-| `scope_reviewer` | `buildReviewerPrompt` | `runReviewerRound` | `buildReviewerSchema` / `ReviewerPayload` | Execute-scope review only. `neal review` external ranges use the separate read-only review-findings loop. Meaningful-progress remains a capability variant of `scope_reviewer`, not a new top-level id. Context includes a run-local `scratchDir`, but read-only reviewer prompts omit it. |
+| `scope_reviewer` | `buildReviewerPrompt` | `runReviewerRound` | `buildReviewerSchema` / `ReviewerPayload` | Execute-scope review only. `neal review` external ranges use the separate read-only review-findings loop. Meaningful-progress remains a capability variant of `scope_reviewer`, not a new top-level id. Context includes a run-local `scratchDir`, but read-only reviewer prompts omit it. Context also includes `earlierScopeChanges` when the current diff touches a file an earlier accepted scope changed (see below). |
 | `completion_coder` | `buildFinalCompletionSummaryPrompt` | `runCoderFinalCompletionSummaryRound` | `buildFinalCompletionSummarySchema` / `parseFinalCompletionSummaryPayload` | Structured advisor round, but still a coder-owned role/task. The completion packet includes aggregate review context when neal can compute it. |
 | `completion_reviewer` | `buildFinalCompletionReviewerPrompt` | `runReviewerFinalCompletionRound` | `buildFinalCompletionReviewerSchema` / `parseFinalCompletionReviewerPayload` | Whole-plan aggregate review remains distinct from ordinary scope review and keeps its final-completion verdict schema. Context includes a run-local `scratchDir`, but read-only reviewer prompts omit it. |
 | `consultant` | `buildConsultantPrompt` | `runConsultantRound` | `buildConsultantSchema` / `validateConsultantVerdictPayload` | Single no-read-safe variant for the read-only consultant. It judges entirely from neal-inlined context and its static instructions pass the shared no-read guard. |
@@ -124,6 +124,26 @@ When adding or changing a prompt spec:
 5. Variant `inputShape` keys must stay a subset of the spec's top-level `requiredContext` keys. neal validates that contract at module load so prompt-spec drift fails fast in tests and at startup.
 
 Final completion has one additional context assembly rule: `buildFinalCompletionPacket()` includes `aggregateReviewContext` for the whole implementation range from `initialBaseCommit` to the resolved final commit. When the range can be read, the packet carries commit subjects, diff stat, and changed files. When it cannot, it carries an explicit `unavailableReason` so the reviewer treats the missing aggregate range as evidence to consider instead of silently accepting completion.
+
+Execute-scope review has one more context assembly rule. The reviewer session
+persists across scopes while the coder session resets, so the reviewer is the
+only participant that remembers earlier scopes, and its record of each one is
+the coder's own summary in the continuity packet. To keep that memory honest,
+`runExecuteReviewerAdjudication` computes `earlierScopeChanges`: for every file
+in the current scope diff that an earlier accepted scope also changed (from
+`completedScopes[].changedFiles` in run state; blocked scopes and scopes
+replaced by a derived plan are skipped), it collects that earlier scope's diff
+restricted to the file (`git diff <scope.baseCommit>..<scope.finalCommit> --
+<file>`, a fixed-argv helper in `src/neal/git.ts`). `buildReviewerPrompt`
+renders them under "Earlier-scope changes to files in this diff", bounded by
+the same inline-section limit as the inlined range diff, and renders nothing
+when there is no overlap. The prompt always carries the matching doctrine line:
+a change to a file an earlier accepted scope signed off must preserve what that
+review accepted, and weakening or removing a test, assertion, or check an
+earlier scope introduced is a blocking finding unless the plan calls for it.
+The continuity packet lists each completed scope's changed files (capped per
+scope, with a count of what was cut) so the reviewer can also see which files
+an earlier scope owned.
 
 Execute-scope and final-completion reviewer context includes a deterministic
 run-local `scratchDir` under `.neal/runs/<run-id>/scratch/`. A `tool-access`

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -86,7 +86,7 @@ neal operations and diagnostics.
 | `.neal/runs/<run-id>/RUN_NARRATIVE.json` | Internal state | Narrative source data that neal may read to update the human narrative. It is not a public trace artifact. |
 | `.neal/runs/<run-id>/REVIEW.md` | User-facing human artifact | Scope or plan review history and findings. |
 | `.neal/runs/<run-id>/REVIEW-<commit>.md` | User-facing human artifact | Archived review history for an accepted scope commit. |
-| `.neal/runs/<run-id>/REVIEWER_CONTEXT.md` | Support/debug artifact | Bounded reviewer-continuity packet rendered for inspection. |
+| `.neal/runs/<run-id>/REVIEWER_CONTEXT.md` | Support/debug artifact | Bounded reviewer-continuity packet rendered for inspection: completed scopes with their changed files, findings, inherited plan-review debt, and citations. |
 | `.neal/runs/<run-id>/REVIEWER_CONTEXT.json` | Support/debug artifact | Machine-readable reviewer-continuity packet without the rendered prompt markdown. |
 | `.neal/runs/<run-id>/RECOVERY.md` | User-facing human artifact | Interactive blocked-recovery transcript/history for a run. |
 | `.neal/runs/<run-id>/FINAL_COMPLETION_REVIEW.md` | User-facing human artifact | Whole-plan final completion review. |

--- a/src/neal/adjudicator/execute.ts
+++ b/src/neal/adjudicator/execute.ts
@@ -4,8 +4,10 @@ import { runCoderResponseRound, runReviewerRound } from '../agents.js';
 import { readOnlyReviewerNeedsInlinedDiff } from '../context/inline-review-context.js';
 import { buildAndPersistReviewerContextPacket } from '../context/reviewer-context.js';
 import { getReviewStuckWindow } from '../config.js';
+import { getDiffForRangePaths } from '../git.js';
 import { EXECUTE_FINALIZATION_PHASE, type ExecuteFinalizationPhase } from '../execute-finalization.js';
 import type { RunLogger } from '../logger.js';
+import type { EarlierScopeFileChange } from '../prompts/execute.js';
 import {
   classifyAlreadySatisfiedTopLevelScopeAcceptance,
   classifyEmptyDerivedParentAdvance,
@@ -413,6 +415,9 @@ export async function runExecuteReviewerAdjudication(args: {
   getDiffStatForRange: (cwd: string, baseCommit: string, headCommit: string) => Promise<string>;
   getChangedFilesForRange: (cwd: string, baseCommit: string, headCommit: string) => Promise<string[]>;
   getDiffForRange: (cwd: string, baseCommit: string, headCommit: string) => Promise<string>;
+  // Path-restricted range diff for earlier-scope overlap context. Optional so
+  // existing callers and fakes stay valid; defaults to the real git helper.
+  getDiffForRangePaths?: (cwd: string, baseCommit: string, headCommit: string, paths: readonly string[]) => Promise<string>;
   runReviewerRound?: ExecuteReviewerRoundRunner;
 }) {
   if (!args.state.baseCommit) {
@@ -438,6 +443,11 @@ export async function runExecuteReviewerAdjudication(args: {
   const inlinedRangeDiff = readOnlyReviewerNeedsInlinedDiff(args.state.agentConfig.reviewer)
     ? await args.getDiffForRange(args.state.cwd, args.state.baseCommit, headCommit)
     : null;
+  const earlierScopeChanges = await collectEarlierScopeChanges({
+    state: args.state,
+    changedFiles,
+    getDiffForRangePaths: args.getDiffForRangePaths ?? getDiffForRangePaths,
+  });
   const reviewerResult = await (args.runReviewerRound ?? runReviewerRound)({
     reviewer: args.state.agentConfig.reviewer,
     // Resume the reviewer's own session. The handle persists across review
@@ -463,6 +473,7 @@ export async function runExecuteReviewerAdjudication(args: {
     scratchDir,
     reviewerContext: await buildAndPersistReviewerContextPacket({ state: args.state }),
     inlinedRangeDiff,
+    earlierScopeChanges,
     unattended: args.state.unattended,
     logger: args.logger,
   });
@@ -475,6 +486,42 @@ export async function runExecuteReviewerAdjudication(args: {
     },
     reviewerResult,
   };
+}
+
+// Files in the current scope's diff that an earlier accepted scope also
+// changed, each paired with that earlier scope's diff restricted to the file.
+// The reviewer session is the only long-lived memory across scopes, and its
+// record of an earlier scope is the coder's summary; this turns "scope 3's
+// file moved during scope 6" into something it reads instead of something it
+// has to remember. Only accepted scopes count, and a scope replaced by a
+// derived plan is skipped because its work was reset. Scopes with no
+// recorded commit range are skipped.
+export async function collectEarlierScopeChanges(args: {
+  state: OrchestrationState;
+  changedFiles: readonly string[];
+  getDiffForRangePaths: (cwd: string, baseCommit: string, headCommit: string, paths: readonly string[]) => Promise<string>;
+}): Promise<EarlierScopeFileChange[]> {
+  const currentFiles = new Set(args.changedFiles);
+  const changes: EarlierScopeFileChange[] = [];
+  for (const scope of args.state.completedScopes) {
+    if (scope.result !== 'accepted' || scope.replacedByDerivedPlanPath || !scope.baseCommit || !scope.finalCommit) {
+      continue;
+    }
+    for (const file of scope.changedFiles) {
+      if (!currentFiles.has(file)) {
+        continue;
+      }
+      const diff = await args.getDiffForRangePaths(args.state.cwd, scope.baseCommit, scope.finalCommit, [file]);
+      changes.push({
+        file,
+        scopeNumber: scope.number,
+        baseCommit: scope.baseCommit,
+        finalCommit: scope.finalCommit,
+        diff,
+      });
+    }
+  }
+  return changes;
 }
 
 function classifyReviewerParentAdvance(args: {

--- a/src/neal/agents/rounds.ts
+++ b/src/neal/agents/rounds.ts
@@ -50,6 +50,7 @@ import {
   buildConsultantPrompt,
   buildScopePrompt,
 } from './prompts.js';
+import type { EarlierScopeFileChange } from '../prompts/execute.js';
 import {
   buildCoderBlockedRecoveryDispositionSchema,
   buildCoderPlanSchema,
@@ -319,6 +320,9 @@ export async function runReviewerRound(args: {
   // Neal-inlined commit-range diff for a read-only reviewer that has read tools
   // but no commit-range diff tool; threaded into buildReviewerPrompt.
   inlinedRangeDiff?: string | null;
+  // Earlier accepted scopes' per-file diffs for files the current diff touches
+  // again; threaded into buildReviewerPrompt.
+  earlierScopeChanges?: readonly EarlierScopeFileChange[] | null;
   // Persisted unattended run flag; threaded into the reviewer prompt variant.
   unattended?: boolean;
   logger?: RunLogger;

--- a/src/neal/context/reviewer-context.ts
+++ b/src/neal/context/reviewer-context.ts
@@ -9,6 +9,10 @@ export const REVIEWER_CONTEXT_MARKDOWN = 'REVIEWER_CONTEXT.md';
 
 const COMPLETED_SCOPE_LIMIT = 12;
 const FINDING_LIMIT = 24;
+// Files listed per completed scope. The full list stays in RUN_STATE.json;
+// the packet carries enough for the reviewer to see which files an earlier
+// scope owned, with an explicit count when the list is cut.
+const COMPLETED_SCOPE_CHANGED_FILE_LIMIT = 20;
 
 export type ReviewerContextCitation = {
   label: string;
@@ -36,6 +40,8 @@ export type ReviewerContextPacket = {
     marker: string;
     finalCommit: string | null;
     summary: string | null;
+    changedFiles: string[];
+    changedFileCount: number;
     reviewRounds: number;
     findings: number;
     residualReviewDebt: number;
@@ -106,6 +112,8 @@ export function buildReviewerContextPacket(args: {
     marker: scope.marker,
     finalCommit: scope.finalCommit,
     summary: scope.summary ?? null,
+    changedFiles: scope.changedFiles.slice(0, COMPLETED_SCOPE_CHANGED_FILE_LIMIT),
+    changedFileCount: scope.changedFiles.length,
     reviewRounds: scope.reviewRounds,
     findings: scope.findings,
     residualReviewDebt: scope.residualReviewDebt?.length ?? 0,
@@ -200,7 +208,7 @@ function buildReviewerContextCitations(state: OrchestrationState): ReviewerConte
 export function renderReviewerContextMarkdown(packet: Omit<ReviewerContextPacket, 'promptMarkdown'>) {
   const scopeLines = packet.completedScopes.length
     ? packet.completedScopes.map((scope) =>
-      `- Scope ${scope.number}: ${scope.result}; marker=${scope.marker}; finalCommit=${scope.finalCommit ?? 'none'}; reviewRounds=${scope.reviewRounds}; findings=${scope.findings}; residualDebt=${scope.residualReviewDebt}; summary=${scope.summary ?? 'none'}`,
+      `- Scope ${scope.number}: ${scope.result}; marker=${scope.marker}; finalCommit=${scope.finalCommit ?? 'none'}; reviewRounds=${scope.reviewRounds}; findings=${scope.findings}; residualDebt=${scope.residualReviewDebt}; files=${formatCompletedScopeFiles(scope)}; summary=${scope.summary ?? 'none'}`,
     )
     : ['- none'];
   const findingLines = packet.findings.length
@@ -252,6 +260,14 @@ export function renderReviewerContextMarkdown(packet: Omit<ReviewerContextPacket
     '## Citations',
     ...packet.citations.map((citation) => `- ${citation.label}: ${citation.path}`),
   ].join('\n');
+}
+
+function formatCompletedScopeFiles(scope: { changedFiles: string[]; changedFileCount: number }) {
+  if (scope.changedFiles.length === 0) {
+    return 'none';
+  }
+  const omitted = scope.changedFileCount - scope.changedFiles.length;
+  return omitted > 0 ? `${scope.changedFiles.join(', ')} (+${omitted} more)` : scope.changedFiles.join(', ');
 }
 
 function runIdFromDir(runDir: string) {

--- a/src/neal/git.ts
+++ b/src/neal/git.ts
@@ -248,6 +248,16 @@ export async function getDiffForRange(cwd: string, base: string, head: string) {
   return runGit(['diff', '--find-renames', `${base}..${head}`], cwd);
 }
 
+// Range diff restricted to the given paths. Fixed argv with a `--` separator,
+// never a shell string, so a path can never be read as a revision or option.
+export async function getDiffForRangePaths(cwd: string, base: string, head: string, paths: readonly string[]) {
+  if (base === head || paths.length === 0) {
+    return '';
+  }
+
+  return runGit(['diff', '--find-renames', `${base}..${head}`, '--', ...paths], cwd);
+}
+
 export async function getChangedFilesForRange(cwd: string, base: string, head: string) {
   if (base === head) {
     return [];

--- a/src/neal/orchestrator/phases/review.ts
+++ b/src/neal/orchestrator/phases/review.ts
@@ -9,6 +9,7 @@ import {
   getChangedFilesForRange,
   getCommitRange,
   getDiffForRange,
+  getDiffForRangePaths,
   getDiffStatForRange,
   getHeadCommit,
 } from '../../git.js';
@@ -64,6 +65,7 @@ export async function runReviewPhase(state: OrchestrationState, statePath: strin
       getDiffStatForRange,
       getChangedFilesForRange,
       getDiffForRange,
+      getDiffForRangePaths,
     }));
     reviewerSynthesis = synthesizeExecuteReviewerState({
       state,

--- a/src/neal/prompts/execute.ts
+++ b/src/neal/prompts/execute.ts
@@ -1,5 +1,5 @@
 import type { ReviewFinding } from '../types.js';
-import { renderInlinedRangeDiffSection } from '../context/inline-review-context.js';
+import { renderInlinedRangeDiffSection, truncateInlineSectionBody } from '../context/inline-review-context.js';
 import type { ReviewerContextPacket } from '../context/reviewer-context.js';
 import {
   AUTONOMY_BLOCKED,
@@ -142,6 +142,26 @@ export function buildLegacyScopePrompt(planDoc: string, progressText: string) {
   ].join('\n');
 }
 
+// One file that an earlier accepted scope changed and the current scope's diff
+// touches again, with the earlier scope's diff restricted to that file. The
+// adjudicator computes these from state.completedScopes (see
+// collectEarlierScopeChanges in src/neal/adjudicator/execute.ts).
+export type EarlierScopeFileChange = {
+  file: string;
+  scopeNumber: string;
+  baseCommit: string;
+  finalCommit: string;
+  diff: string;
+};
+
+export const EARLIER_SCOPE_CHANGES_SECTION_HEADING = '## Earlier-scope changes to files in this diff';
+
+// Rendered for every execute-scope review, with or without an overlap: a
+// tool-access reviewer can find earlier-scope history itself, and the rule
+// about what that history means must not depend on whether Neal inlined it.
+const EARLIER_SCOPE_PRESERVATION_LINE =
+  "A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.";
+
 export function buildReviewerPrompt(args: {
   planDoc: string;
   baseCommit: string;
@@ -165,6 +185,10 @@ export function buildReviewerPrompt(args: {
   // Neal-inlined commit-range diff for a read-only reviewer that has read tools
   // but no commit-range diff tool. Only rendered when accessMode is 'read-only'.
   inlinedRangeDiff?: string | null;
+  // Files in the current diff that an earlier accepted scope also changed, each
+  // with that earlier scope's per-file diff. Rendered in every access mode when
+  // non-empty; omitted entirely when there is no overlap.
+  earlierScopeChanges?: readonly EarlierScopeFileChange[] | null;
   // Explicit reviewer doctrine access mode. Defaults to 'tool-access'.
   accessMode?: ReviewDoctrineAccessMode;
   // When true, the run is unattended: render the no-operator autonomy line.
@@ -232,6 +256,7 @@ export function buildReviewerPrompt(args: {
     ...getFindingQualityLines(),
     ...skepticismLines,
     ...regressionLines,
+    EARLIER_SCOPE_PRESERVATION_LINE,
     ...preexistingLines,
     args.previousHeadCommit
       ? `Previous reviewer head was ${args.previousHeadCommit}. Focus especially on changes since that commit, while still considering the full current state.`
@@ -280,6 +305,33 @@ export function buildReviewerPrompt(args: {
           }),
         ]
       : []),
+    ...(args.earlierScopeChanges && args.earlierScopeChanges.length > 0
+      ? ['', renderEarlierScopeChangesSection(args.earlierScopeChanges)]
+      : []),
+  ].join('\n');
+}
+
+// Earlier accepted scopes' per-file diffs for files the current diff touches
+// again. The body shares the inlined-diff bound (truncateInlineSectionBody),
+// which appends an explicit truncation marker instead of dropping content
+// silently.
+function renderEarlierScopeChangesSection(changes: readonly EarlierScopeFileChange[]) {
+  const body = changes
+    .map((change) =>
+      [
+        `### ${change.file} (scope ${change.scopeNumber}, ${change.baseCommit}..${change.finalCommit})`,
+        '',
+        change.diff.trim() === '' ? '(empty diff)' : change.diff,
+      ].join('\n'),
+    )
+    .join('\n\n');
+  return [
+    EARLIER_SCOPE_CHANGES_SECTION_HEADING,
+    '',
+    'The files below were changed by an earlier accepted scope in this run and appear again in the current diff. Each entry shows what that earlier scope did to the file, so what the current scope alters is something you read here rather than something you have to remember.',
+    'Check the current diff against each entry before accepting.',
+    '',
+    truncateInlineSectionBody(body),
   ].join('\n');
 }
 

--- a/src/neal/prompts/specs.ts
+++ b/src/neal/prompts/specs.ts
@@ -191,6 +191,12 @@ const SCOPE_REVIEWER_CONTEXT = context('ScopeReviewerPromptContext', [
   field('reviewMarkdownPath', 'run_artifact', true, 'Review artifact that carries prior findings and coder responses.'),
   field('scratchDir', 'run_artifact', true, 'Run-local reviewer scratch directory for temporary verification artifacts.'),
   field(
+    'earlierScopeChanges',
+    'repository_state',
+    false,
+    'Files in the current scope diff that an earlier accepted scope also changed, each with that scope number, commit range, and per-file diff. Computed from completedScopes in run state; omitted when there is no overlap.',
+  ),
+  field(
     'accessMode',
     'orchestrator_state',
     false,
@@ -537,7 +543,7 @@ export const PROMPT_SPECS: readonly PromptSpec[] = [
   },
   {
     id: 'scope_reviewer',
-    version: 2,
+    version: 3,
     changelog: [
       {
         version: 1,
@@ -546,6 +552,10 @@ export const PROMPT_SPECS: readonly PromptSpec[] = [
       {
         version: 2,
         renderSha: '431a75ad341a531535606af607187239a31d12cf921575eb17774b317ad639a0',
+      },
+      {
+        version: 3,
+        renderSha: '4b75fab01367f0e4e263bc7635f8753e8e73c08b3ca46cf6bb6e695a67da31a4',
       },
     ],
     role: 'reviewer',
@@ -570,11 +580,18 @@ export const PROMPT_SPECS: readonly PromptSpec[] = [
         field('reviewMarkdownPath', 'run_artifact', true, 'Review history artifact path.'),
         field('progressJustification', 'review_history', true, 'Coder progress-justification payload.'),
         field('scratchDir', 'run_artifact', true, 'Run-local scratch directory for reviewer verification artifacts.'),
+        field(
+          'earlierScopeChanges',
+          'repository_state',
+          false,
+          'Earlier accepted scopes\' per-file diffs for files the current diff touches again; absent when there is no overlap.',
+        ),
       ]),
     },
     providerVariants: SHARED_PROVIDER_VARIANTS,
     evaluationNotes: [
       'Render tests should assert reviewer prompts include shared adversarial falsification, verification skepticism, concrete finding-quality doctrine, meaningful-progress instructions, and parent-objective history.',
+      'Render tests should assert the earlier-scope preservation line renders in every cell and the earlier-scope changes section renders only when an overlap is supplied.',
       'Future fixture cases should cover cases where local correctness differs from parent-objective convergence.',
     ],
     firstMigrationPriority: 2,

--- a/test/context-pack.test.ts
+++ b/test/context-pack.test.ts
@@ -260,7 +260,11 @@ test('reviewer context packet is bounded and persists citations instead of full 
         finalCommit: `commit-${index + 1}`,
         summary: `Accepted scope ${index + 1}`,
         commitSubject: `Commit scope ${index + 1}`,
-        changedFiles: [`src/file-${index + 1}.ts`],
+        // Scope 3 carries 25 files so the per-scope file cap is exercised.
+        changedFiles:
+          index + 1 === 3
+            ? Array.from({ length: 25 }, (_, fileIndex) => `src/scope3/file-${fileIndex + 1}.ts`)
+            : [`src/file-${index + 1}.ts`],
         reviewRounds: 1,
         findings: index,
         residualReviewDebt: [],
@@ -297,6 +301,15 @@ test('reviewer context packet is bounded and persists citations instead of full 
   assert.equal(packet.createdAt, '2026-04-25T18:15:52.082Z');
   assert.equal(packet.completedScopes.length, 12);
   assert.equal(packet.completedScopes[0]?.number, '3');
+  // Each completed scope names the files it changed (issue #10), capped per
+  // scope with an explicit count of what was cut.
+  assert.equal(packet.completedScopes[0]?.changedFiles.length, 20);
+  assert.equal(packet.completedScopes[0]?.changedFileCount, 25);
+  assert.deepEqual(packet.completedScopes[1]?.changedFiles, ['src/file-4.ts']);
+  assert.equal(packet.completedScopes[1]?.changedFileCount, 1);
+  assert.match(packet.promptMarkdown, /Scope 4: .*files=src\/file-4\.ts;/);
+  assert.match(packet.promptMarkdown, /Scope 3: .*src\/scope3\/file-20\.ts \(\+5 more\);/);
+  assert.doesNotMatch(packet.promptMarkdown, /src\/scope3\/file-21\.ts/);
   assert.equal(packet.findings.length, 24);
   assert.equal(packet.findings[0]?.canonicalId, 'canonical-5');
   assert.equal(packet.limits.truncatedCompletedScopes, true);

--- a/test/fixtures/prompts/render-integrity/scope_reviewer.v3.txt
+++ b/test/fixtures/prompts/render-integrity/scope_reviewer.v3.txt
@@ -1,0 +1,2968 @@
+=== buildReviewerPrompt#accessMode=read-only-inlined#earlierScopeChanges=absent#previousHead=absent#unattended=false ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+The commit-range diff for that commit range is inlined below and is the source of truth for exactly what the commit range changed (including deletions and renames). Use your read tools to verify the surrounding code; you have no commit-range diff tool, so rely on the inlined diff for what changed.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Inspect the change using the inlined commit-range diff below for what changed (including deletions and renames), then read the changed files in full with your read tools and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+This is the first reviewer round for this scope.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+
+## Inlined commit-range diff from Neal (base000..head000)
+
+You have read-only repository tools (read and search, no shell) but no commit-range diff tool, so Neal has inlined the commit-range diff below.
+This inlined diff is the source of truth for exactly what this range changed, including deletions and renames that head-state file reads cannot reveal. Use your read tools to verify the surrounding code.
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-old
++new
+
+=== buildReviewerPrompt#accessMode=read-only-inlined#earlierScopeChanges=absent#previousHead=absent#unattended=true ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+The commit-range diff for that commit range is inlined below and is the source of truth for exactly what the commit range changed (including deletions and renames). Use your read tools to verify the surrounding code; you have no commit-range diff tool, so rely on the inlined diff for what changed.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Inspect the change using the inlined commit-range diff below for what changed (including deletions and renames), then read the changed files in full with your read tools and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+This is the first reviewer round for this scope.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+No operator is available to answer. Resolve this autonomously: do not escalate for operator guidance; make your best judgment and keep all verification requirements intact.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+
+## Inlined commit-range diff from Neal (base000..head000)
+
+You have read-only repository tools (read and search, no shell) but no commit-range diff tool, so Neal has inlined the commit-range diff below.
+This inlined diff is the source of truth for exactly what this range changed, including deletions and renames that head-state file reads cannot reveal. Use your read tools to verify the surrounding code.
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-old
++new
+
+=== buildReviewerPrompt#accessMode=read-only-inlined#earlierScopeChanges=absent#previousHead=present#unattended=false ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+The commit-range diff for that commit range is inlined below and is the source of truth for exactly what the commit range changed (including deletions and renames). Use your read tools to verify the surrounding code; you have no commit-range diff tool, so rely on the inlined diff for what changed.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Inspect the change using the inlined commit-range diff below for what changed (including deletions and renames), then read the changed files in full with your read tools and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Previous reviewer head was prevhead000. Focus especially on changes since that commit, while still considering the full current state.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+
+## Inlined commit-range diff from Neal (base000..head000)
+
+You have read-only repository tools (read and search, no shell) but no commit-range diff tool, so Neal has inlined the commit-range diff below.
+This inlined diff is the source of truth for exactly what this range changed, including deletions and renames that head-state file reads cannot reveal. Use your read tools to verify the surrounding code.
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-old
++new
+
+=== buildReviewerPrompt#accessMode=read-only-inlined#earlierScopeChanges=absent#previousHead=present#unattended=true ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+The commit-range diff for that commit range is inlined below and is the source of truth for exactly what the commit range changed (including deletions and renames). Use your read tools to verify the surrounding code; you have no commit-range diff tool, so rely on the inlined diff for what changed.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Inspect the change using the inlined commit-range diff below for what changed (including deletions and renames), then read the changed files in full with your read tools and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Previous reviewer head was prevhead000. Focus especially on changes since that commit, while still considering the full current state.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+No operator is available to answer. Resolve this autonomously: do not escalate for operator guidance; make your best judgment and keep all verification requirements intact.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+
+## Inlined commit-range diff from Neal (base000..head000)
+
+You have read-only repository tools (read and search, no shell) but no commit-range diff tool, so Neal has inlined the commit-range diff below.
+This inlined diff is the source of truth for exactly what this range changed, including deletions and renames that head-state file reads cannot reveal. Use your read tools to verify the surrounding code.
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-old
++new
+
+=== buildReviewerPrompt#accessMode=read-only-inlined#earlierScopeChanges=present#previousHead=absent#unattended=false ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+The commit-range diff for that commit range is inlined below and is the source of truth for exactly what the commit range changed (including deletions and renames). Use your read tools to verify the surrounding code; you have no commit-range diff tool, so rely on the inlined diff for what changed.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Inspect the change using the inlined commit-range diff below for what changed (including deletions and renames), then read the changed files in full with your read tools and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+This is the first reviewer round for this scope.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+
+## Inlined commit-range diff from Neal (base000..head000)
+
+You have read-only repository tools (read and search, no shell) but no commit-range diff tool, so Neal has inlined the commit-range diff below.
+This inlined diff is the source of truth for exactly what this range changed, including deletions and renames that head-state file reads cannot reveal. Use your read tools to verify the surrounding code.
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-old
++new
+
+
+## Earlier-scope changes to files in this diff
+
+The files below were changed by an earlier accepted scope in this run and appear again in the current diff. Each entry shows what that earlier scope did to the file, so what the current scope alters is something you read here rather than something you have to remember.
+Check the current diff against each entry before accepting.
+
+### src/example.ts (scope 3, scope3base000..scope3final000)
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-older
++old
+
+=== buildReviewerPrompt#accessMode=read-only-inlined#earlierScopeChanges=present#previousHead=absent#unattended=true ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+The commit-range diff for that commit range is inlined below and is the source of truth for exactly what the commit range changed (including deletions and renames). Use your read tools to verify the surrounding code; you have no commit-range diff tool, so rely on the inlined diff for what changed.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Inspect the change using the inlined commit-range diff below for what changed (including deletions and renames), then read the changed files in full with your read tools and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+This is the first reviewer round for this scope.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+No operator is available to answer. Resolve this autonomously: do not escalate for operator guidance; make your best judgment and keep all verification requirements intact.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+
+## Inlined commit-range diff from Neal (base000..head000)
+
+You have read-only repository tools (read and search, no shell) but no commit-range diff tool, so Neal has inlined the commit-range diff below.
+This inlined diff is the source of truth for exactly what this range changed, including deletions and renames that head-state file reads cannot reveal. Use your read tools to verify the surrounding code.
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-old
++new
+
+
+## Earlier-scope changes to files in this diff
+
+The files below were changed by an earlier accepted scope in this run and appear again in the current diff. Each entry shows what that earlier scope did to the file, so what the current scope alters is something you read here rather than something you have to remember.
+Check the current diff against each entry before accepting.
+
+### src/example.ts (scope 3, scope3base000..scope3final000)
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-older
++old
+
+=== buildReviewerPrompt#accessMode=read-only-inlined#earlierScopeChanges=present#previousHead=present#unattended=false ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+The commit-range diff for that commit range is inlined below and is the source of truth for exactly what the commit range changed (including deletions and renames). Use your read tools to verify the surrounding code; you have no commit-range diff tool, so rely on the inlined diff for what changed.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Inspect the change using the inlined commit-range diff below for what changed (including deletions and renames), then read the changed files in full with your read tools and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Previous reviewer head was prevhead000. Focus especially on changes since that commit, while still considering the full current state.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+
+## Inlined commit-range diff from Neal (base000..head000)
+
+You have read-only repository tools (read and search, no shell) but no commit-range diff tool, so Neal has inlined the commit-range diff below.
+This inlined diff is the source of truth for exactly what this range changed, including deletions and renames that head-state file reads cannot reveal. Use your read tools to verify the surrounding code.
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-old
++new
+
+
+## Earlier-scope changes to files in this diff
+
+The files below were changed by an earlier accepted scope in this run and appear again in the current diff. Each entry shows what that earlier scope did to the file, so what the current scope alters is something you read here rather than something you have to remember.
+Check the current diff against each entry before accepting.
+
+### src/example.ts (scope 3, scope3base000..scope3final000)
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-older
++old
+
+=== buildReviewerPrompt#accessMode=read-only-inlined#earlierScopeChanges=present#previousHead=present#unattended=true ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+The commit-range diff for that commit range is inlined below and is the source of truth for exactly what the commit range changed (including deletions and renames). Use your read tools to verify the surrounding code; you have no commit-range diff tool, so rely on the inlined diff for what changed.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Inspect the change using the inlined commit-range diff below for what changed (including deletions and renames), then read the changed files in full with your read tools and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Previous reviewer head was prevhead000. Focus especially on changes since that commit, while still considering the full current state.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+No operator is available to answer. Resolve this autonomously: do not escalate for operator guidance; make your best judgment and keep all verification requirements intact.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+
+## Inlined commit-range diff from Neal (base000..head000)
+
+You have read-only repository tools (read and search, no shell) but no commit-range diff tool, so Neal has inlined the commit-range diff below.
+This inlined diff is the source of truth for exactly what this range changed, including deletions and renames that head-state file reads cannot reveal. Use your read tools to verify the surrounding code.
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-old
++new
+
+
+## Earlier-scope changes to files in this diff
+
+The files below were changed by an earlier accepted scope in this run and appear again in the current diff. Each entry shows what that earlier scope did to the file, so what the current scope alters is something you read here rather than something you have to remember.
+Check the current diff against each entry before accepting.
+
+### src/example.ts (scope 3, scope3base000..scope3final000)
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-older
++old
+
+=== buildReviewerPrompt#accessMode=read-only-tool#earlierScopeChanges=absent#previousHead=absent#unattended=false ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+Review that commit range directly with your read-only repository tools: use the git_diff tool to see exactly what the commit range changed (including deletions and renames), and your read tools to verify the surrounding code. The commit range is the source of truth for this review.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Inspect the change with your read-only tools: call git_diff with the base and head commits named in this prompt (stat:true first for the changed-file overview, then per-path diffs), read the changed files in full, and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+This is the first reviewer round for this scope.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+=== buildReviewerPrompt#accessMode=read-only-tool#earlierScopeChanges=absent#previousHead=absent#unattended=true ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+Review that commit range directly with your read-only repository tools: use the git_diff tool to see exactly what the commit range changed (including deletions and renames), and your read tools to verify the surrounding code. The commit range is the source of truth for this review.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Inspect the change with your read-only tools: call git_diff with the base and head commits named in this prompt (stat:true first for the changed-file overview, then per-path diffs), read the changed files in full, and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+This is the first reviewer round for this scope.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+No operator is available to answer. Resolve this autonomously: do not escalate for operator guidance; make your best judgment and keep all verification requirements intact.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+=== buildReviewerPrompt#accessMode=read-only-tool#earlierScopeChanges=absent#previousHead=present#unattended=false ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+Review that commit range directly with your read-only repository tools: use the git_diff tool to see exactly what the commit range changed (including deletions and renames), and your read tools to verify the surrounding code. The commit range is the source of truth for this review.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Inspect the change with your read-only tools: call git_diff with the base and head commits named in this prompt (stat:true first for the changed-file overview, then per-path diffs), read the changed files in full, and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Previous reviewer head was prevhead000. Focus especially on changes since that commit, while still considering the full current state.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+=== buildReviewerPrompt#accessMode=read-only-tool#earlierScopeChanges=absent#previousHead=present#unattended=true ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+Review that commit range directly with your read-only repository tools: use the git_diff tool to see exactly what the commit range changed (including deletions and renames), and your read tools to verify the surrounding code. The commit range is the source of truth for this review.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Inspect the change with your read-only tools: call git_diff with the base and head commits named in this prompt (stat:true first for the changed-file overview, then per-path diffs), read the changed files in full, and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Previous reviewer head was prevhead000. Focus especially on changes since that commit, while still considering the full current state.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+No operator is available to answer. Resolve this autonomously: do not escalate for operator guidance; make your best judgment and keep all verification requirements intact.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+=== buildReviewerPrompt#accessMode=read-only-tool#earlierScopeChanges=present#previousHead=absent#unattended=false ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+Review that commit range directly with your read-only repository tools: use the git_diff tool to see exactly what the commit range changed (including deletions and renames), and your read tools to verify the surrounding code. The commit range is the source of truth for this review.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Inspect the change with your read-only tools: call git_diff with the base and head commits named in this prompt (stat:true first for the changed-file overview, then per-path diffs), read the changed files in full, and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+This is the first reviewer round for this scope.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+
+## Earlier-scope changes to files in this diff
+
+The files below were changed by an earlier accepted scope in this run and appear again in the current diff. Each entry shows what that earlier scope did to the file, so what the current scope alters is something you read here rather than something you have to remember.
+Check the current diff against each entry before accepting.
+
+### src/example.ts (scope 3, scope3base000..scope3final000)
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-older
++old
+
+=== buildReviewerPrompt#accessMode=read-only-tool#earlierScopeChanges=present#previousHead=absent#unattended=true ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+Review that commit range directly with your read-only repository tools: use the git_diff tool to see exactly what the commit range changed (including deletions and renames), and your read tools to verify the surrounding code. The commit range is the source of truth for this review.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Inspect the change with your read-only tools: call git_diff with the base and head commits named in this prompt (stat:true first for the changed-file overview, then per-path diffs), read the changed files in full, and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+This is the first reviewer round for this scope.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+No operator is available to answer. Resolve this autonomously: do not escalate for operator guidance; make your best judgment and keep all verification requirements intact.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+
+## Earlier-scope changes to files in this diff
+
+The files below were changed by an earlier accepted scope in this run and appear again in the current diff. Each entry shows what that earlier scope did to the file, so what the current scope alters is something you read here rather than something you have to remember.
+Check the current diff against each entry before accepting.
+
+### src/example.ts (scope 3, scope3base000..scope3final000)
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-older
++old
+
+=== buildReviewerPrompt#accessMode=read-only-tool#earlierScopeChanges=present#previousHead=present#unattended=false ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+Review that commit range directly with your read-only repository tools: use the git_diff tool to see exactly what the commit range changed (including deletions and renames), and your read tools to verify the surrounding code. The commit range is the source of truth for this review.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Inspect the change with your read-only tools: call git_diff with the base and head commits named in this prompt (stat:true first for the changed-file overview, then per-path diffs), read the changed files in full, and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Previous reviewer head was prevhead000. Focus especially on changes since that commit, while still considering the full current state.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+
+## Earlier-scope changes to files in this diff
+
+The files below were changed by an earlier accepted scope in this run and appear again in the current diff. Each entry shows what that earlier scope did to the file, so what the current scope alters is something you read here rather than something you have to remember.
+Check the current diff against each entry before accepting.
+
+### src/example.ts (scope 3, scope3base000..scope3final000)
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-older
++old
+
+=== buildReviewerPrompt#accessMode=read-only-tool#earlierScopeChanges=present#previousHead=present#unattended=true ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+Review that commit range directly with your read-only repository tools: use the git_diff tool to see exactly what the commit range changed (including deletions and renames), and your read tools to verify the surrounding code. The commit range is the source of truth for this review.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Inspect the change with your read-only tools: call git_diff with the base and head commits named in this prompt (stat:true first for the changed-file overview, then per-path diffs), read the changed files in full, and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Previous reviewer head was prevhead000. Focus especially on changes since that commit, while still considering the full current state.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+No operator is available to answer. Resolve this autonomously: do not escalate for operator guidance; make your best judgment and keep all verification requirements intact.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+
+## Earlier-scope changes to files in this diff
+
+The files below were changed by an earlier accepted scope in this run and appear again in the current diff. Each entry shows what that earlier scope did to the file, so what the current scope alters is something you read here rather than something you have to remember.
+Check the current diff against each entry before accepting.
+
+### src/example.ts (scope 3, scope3base000..scope3final000)
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-older
++old
+
+=== buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=absent#previousHead=absent#unattended=false ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+Review that commit range directly with repository tools. The commit range is the source of truth for this review.
+Use git commands against the repository, for example: git diff base000..head000, git show --stat head000, and targeted path diffs or file reads for changed files.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Temporary verification scratch directory: /tmp/repo/.neal/runs/run-000/scratch/review
+Use that run-local scratch directory for temporary verification artifacts, copied tests, scratch builds, logs, and modified throwaway files.
+Do not create project-root scratch directories such as build_review/.
+Do not leave project-tree scratch files behind; keep scratch work under the run-local directory above.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — running them when available — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, exercise or reason through the affected existing flows directly — run the most relevant existing tests or reproduce the reported behavior when practical — rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+This is the first reviewer round for this scope.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+=== buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=absent#previousHead=absent#unattended=true ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+Review that commit range directly with repository tools. The commit range is the source of truth for this review.
+Use git commands against the repository, for example: git diff base000..head000, git show --stat head000, and targeted path diffs or file reads for changed files.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Temporary verification scratch directory: /tmp/repo/.neal/runs/run-000/scratch/review
+Use that run-local scratch directory for temporary verification artifacts, copied tests, scratch builds, logs, and modified throwaway files.
+Do not create project-root scratch directories such as build_review/.
+Do not leave project-tree scratch files behind; keep scratch work under the run-local directory above.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — running them when available — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, exercise or reason through the affected existing flows directly — run the most relevant existing tests or reproduce the reported behavior when practical — rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+This is the first reviewer round for this scope.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+No operator is available to answer. Resolve this autonomously: do not escalate for operator guidance; make your best judgment and keep all verification requirements intact.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+=== buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=absent#previousHead=present#unattended=false ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+Review that commit range directly with repository tools. The commit range is the source of truth for this review.
+Use git commands against the repository, for example: git diff base000..head000, git show --stat head000, and targeted path diffs or file reads for changed files.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Temporary verification scratch directory: /tmp/repo/.neal/runs/run-000/scratch/review
+Use that run-local scratch directory for temporary verification artifacts, copied tests, scratch builds, logs, and modified throwaway files.
+Do not create project-root scratch directories such as build_review/.
+Do not leave project-tree scratch files behind; keep scratch work under the run-local directory above.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — running them when available — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, exercise or reason through the affected existing flows directly — run the most relevant existing tests or reproduce the reported behavior when practical — rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Previous reviewer head was prevhead000. Focus especially on changes since that commit, while still considering the full current state.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+=== buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=absent#previousHead=present#unattended=true ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+Review that commit range directly with repository tools. The commit range is the source of truth for this review.
+Use git commands against the repository, for example: git diff base000..head000, git show --stat head000, and targeted path diffs or file reads for changed files.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Temporary verification scratch directory: /tmp/repo/.neal/runs/run-000/scratch/review
+Use that run-local scratch directory for temporary verification artifacts, copied tests, scratch builds, logs, and modified throwaway files.
+Do not create project-root scratch directories such as build_review/.
+Do not leave project-tree scratch files behind; keep scratch work under the run-local directory above.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — running them when available — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, exercise or reason through the affected existing flows directly — run the most relevant existing tests or reproduce the reported behavior when practical — rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Previous reviewer head was prevhead000. Focus especially on changes since that commit, while still considering the full current state.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+No operator is available to answer. Resolve this autonomously: do not escalate for operator guidance; make your best judgment and keep all verification requirements intact.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+=== buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=present#previousHead=absent#unattended=false ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+Review that commit range directly with repository tools. The commit range is the source of truth for this review.
+Use git commands against the repository, for example: git diff base000..head000, git show --stat head000, and targeted path diffs or file reads for changed files.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Temporary verification scratch directory: /tmp/repo/.neal/runs/run-000/scratch/review
+Use that run-local scratch directory for temporary verification artifacts, copied tests, scratch builds, logs, and modified throwaway files.
+Do not create project-root scratch directories such as build_review/.
+Do not leave project-tree scratch files behind; keep scratch work under the run-local directory above.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — running them when available — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, exercise or reason through the affected existing flows directly — run the most relevant existing tests or reproduce the reported behavior when practical — rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+This is the first reviewer round for this scope.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+
+## Earlier-scope changes to files in this diff
+
+The files below were changed by an earlier accepted scope in this run and appear again in the current diff. Each entry shows what that earlier scope did to the file, so what the current scope alters is something you read here rather than something you have to remember.
+Check the current diff against each entry before accepting.
+
+### src/example.ts (scope 3, scope3base000..scope3final000)
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-older
++old
+
+=== buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=present#previousHead=absent#unattended=true ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+Review that commit range directly with repository tools. The commit range is the source of truth for this review.
+Use git commands against the repository, for example: git diff base000..head000, git show --stat head000, and targeted path diffs or file reads for changed files.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Temporary verification scratch directory: /tmp/repo/.neal/runs/run-000/scratch/review
+Use that run-local scratch directory for temporary verification artifacts, copied tests, scratch builds, logs, and modified throwaway files.
+Do not create project-root scratch directories such as build_review/.
+Do not leave project-tree scratch files behind; keep scratch work under the run-local directory above.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — running them when available — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, exercise or reason through the affected existing flows directly — run the most relevant existing tests or reproduce the reported behavior when practical — rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+This is the first reviewer round for this scope.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+No operator is available to answer. Resolve this autonomously: do not escalate for operator guidance; make your best judgment and keep all verification requirements intact.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+
+## Earlier-scope changes to files in this diff
+
+The files below were changed by an earlier accepted scope in this run and appear again in the current diff. Each entry shows what that earlier scope did to the file, so what the current scope alters is something you read here rather than something you have to remember.
+Check the current diff against each entry before accepting.
+
+### src/example.ts (scope 3, scope3base000..scope3final000)
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-older
++old
+
+=== buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=present#previousHead=present#unattended=false ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+Review that commit range directly with repository tools. The commit range is the source of truth for this review.
+Use git commands against the repository, for example: git diff base000..head000, git show --stat head000, and targeted path diffs or file reads for changed files.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Temporary verification scratch directory: /tmp/repo/.neal/runs/run-000/scratch/review
+Use that run-local scratch directory for temporary verification artifacts, copied tests, scratch builds, logs, and modified throwaway files.
+Do not create project-root scratch directories such as build_review/.
+Do not leave project-tree scratch files behind; keep scratch work under the run-local directory above.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — running them when available — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, exercise or reason through the affected existing flows directly — run the most relevant existing tests or reproduce the reported behavior when practical — rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Previous reviewer head was prevhead000. Focus especially on changes since that commit, while still considering the full current state.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+
+## Earlier-scope changes to files in this diff
+
+The files below were changed by an earlier accepted scope in this run and appear again in the current diff. Each entry shows what that earlier scope did to the file, so what the current scope alters is something you read here rather than something you have to remember.
+Check the current diff against each entry before accepting.
+
+### src/example.ts (scope 3, scope3base000..scope3final000)
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-older
++old
+
+=== buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=present#previousHead=present#unattended=true ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+Review that commit range directly with repository tools. The commit range is the source of truth for this review.
+Use git commands against the repository, for example: git diff base000..head000, git show --stat head000, and targeted path diffs or file reads for changed files.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Temporary verification scratch directory: /tmp/repo/.neal/runs/run-000/scratch/review
+Use that run-local scratch directory for temporary verification artifacts, copied tests, scratch builds, logs, and modified throwaway files.
+Do not create project-root scratch directories such as build_review/.
+Do not leave project-tree scratch files behind; keep scratch work under the run-local directory above.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — running them when available — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, exercise or reason through the affected existing flows directly — run the most relevant existing tests or reproduce the reported behavior when practical — rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Previous reviewer head was prevhead000. Focus especially on changes since that commit, while still considering the full current state.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+No operator is available to answer. Resolve this autonomously: do not escalate for operator guidance; make your best judgment and keep all verification requirements intact.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+
+## Earlier-scope changes to files in this diff
+
+The files below were changed by an earlier accepted scope in this run and appear again in the current diff. Each entry shows what that earlier scope did to the file, so what the current scope alters is something you read here rather than something you have to remember.
+Check the current diff against each entry before accepting.
+
+### src/example.ts (scope 3, scope3base000..scope3final000)
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-older
++old
+

--- a/test/git-range-paths.test.ts
+++ b/test/git-range-paths.test.ts
@@ -1,0 +1,52 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+
+import { getDiffForRangePaths } from '../src/neal/git.js';
+
+const execFileAsync = promisify(execFile);
+
+async function git(cwd: string, ...args: string[]) {
+  const { stdout } = await execFileAsync('git', args, { cwd });
+  return stdout.trim();
+}
+
+async function createRepo() {
+  const cwd = await mkdtemp(join(tmpdir(), 'neal-git-range-paths-'));
+  await git(cwd, 'init');
+  await git(cwd, 'config', 'user.email', 'test@example.invalid');
+  await git(cwd, 'config', 'user.name', 'test');
+  await git(cwd, 'config', 'commit.gpgsign', 'false');
+  await writeFile(join(cwd, 'a.ts'), 'export const a = 1;\n');
+  await writeFile(join(cwd, 'b.ts'), 'export const b = 1;\n');
+  await git(cwd, 'add', '.');
+  await git(cwd, 'commit', '-m', 'seed');
+  const base = await git(cwd, 'rev-parse', 'HEAD');
+  await writeFile(join(cwd, 'a.ts'), 'export const a = 2;\n');
+  await writeFile(join(cwd, 'b.ts'), 'export const b = 2;\n');
+  await git(cwd, 'add', '.');
+  await git(cwd, 'commit', '-m', 'change both');
+  const head = await git(cwd, 'rev-parse', 'HEAD');
+  return { cwd, base, head };
+}
+
+// Issue #10: the scope reviewer gets an earlier scope's diff restricted to the
+// files the current diff touches again, so the helper must confine the diff to
+// the requested paths and never read a path as a revision.
+test('getDiffForRangePaths returns only the requested paths for the range', async () => {
+  const { cwd, base, head } = await createRepo();
+
+  const diff = await getDiffForRangePaths(cwd, base, head, ['a.ts']);
+  assert.match(diff, /diff --git a\/a\.ts b\/a\.ts/);
+  assert.match(diff, /\+export const a = 2;/);
+  assert.doesNotMatch(diff, /b\.ts/);
+
+  assert.equal(await getDiffForRangePaths(cwd, base, head, []), '');
+  assert.equal(await getDiffForRangePaths(cwd, head, head, ['a.ts']), '');
+  // A path that does not exist in the range yields an empty diff, not an error.
+  assert.equal(await getDiffForRangePaths(cwd, base, head, ['missing.ts']), '');
+});

--- a/test/prompt-render-integrity.test.ts
+++ b/test/prompt-render-integrity.test.ts
@@ -77,6 +77,19 @@ const PROGRESS_JUSTIFICATION = {
 
 const CANNED_RANGE_DIFF = 'diff --git a/src/example.ts b/src/example.ts\n@@ -1 +1 @@\n-old\n+new\n';
 
+// One earlier accepted scope's per-file diff for a file the current diff
+// touches again (buildReviewerPrompt earlierScopeChanges). Production computes
+// these from completedScopes (collectEarlierScopeChanges, adjudicator/execute.ts).
+const CANNED_EARLIER_SCOPE_CHANGES = [
+  {
+    file: 'src/example.ts',
+    scopeNumber: '3',
+    baseCommit: 'scope3base000',
+    finalCommit: 'scope3final000',
+    diff: 'diff --git a/src/example.ts b/src/example.ts\n@@ -1 +1 @@\n-older\n+old\n',
+  },
+];
+
 // Consultant-only inline context: the blocked-run consultant is the sole
 // surviving consumer of the Neal-inlined context channel.
 const CANNED_INLINE_CONTEXT: InlineReviewerContext = {
@@ -361,6 +374,7 @@ const reviewerSpec: BuilderMatrixSpec = {
   exportName: 'buildReviewerPrompt',
   axes: [
     { name: 'accessMode', values: ['tool-access', 'read-only-inlined', 'read-only-tool'] },
+    { name: 'earlierScopeChanges', values: ['present', 'absent'] },
     { name: 'previousHead', values: ['present', 'absent'] },
     { name: 'unattended', values: ['true', 'false'] },
   ],
@@ -382,6 +396,7 @@ const reviewerSpec: BuilderMatrixSpec = {
       scratchDir: SCRATCH_DIR,
       reviewerContext: CANNED_REVIEWER_PACKET,
       inlinedRangeDiff: c.accessMode === 'read-only-inlined' ? CANNED_RANGE_DIFF : null,
+      earlierScopeChanges: c.earlierScopeChanges === 'present' ? CANNED_EARLIER_SCOPE_CHANGES : null,
       accessMode,
       unattended: c.unattended === 'true',
     });
@@ -564,18 +579,30 @@ const EXPECTED_KEYS: Record<PromptSpecId, string[]> = {
     'buildScopePrompt#unattended=true',
   ],
   scope_reviewer: [
-    'buildReviewerPrompt#accessMode=read-only-inlined#previousHead=absent#unattended=false',
-    'buildReviewerPrompt#accessMode=read-only-inlined#previousHead=absent#unattended=true',
-    'buildReviewerPrompt#accessMode=read-only-inlined#previousHead=present#unattended=false',
-    'buildReviewerPrompt#accessMode=read-only-inlined#previousHead=present#unattended=true',
-    'buildReviewerPrompt#accessMode=read-only-tool#previousHead=absent#unattended=false',
-    'buildReviewerPrompt#accessMode=read-only-tool#previousHead=absent#unattended=true',
-    'buildReviewerPrompt#accessMode=read-only-tool#previousHead=present#unattended=false',
-    'buildReviewerPrompt#accessMode=read-only-tool#previousHead=present#unattended=true',
-    'buildReviewerPrompt#accessMode=tool-access#previousHead=absent#unattended=false',
-    'buildReviewerPrompt#accessMode=tool-access#previousHead=absent#unattended=true',
-    'buildReviewerPrompt#accessMode=tool-access#previousHead=present#unattended=false',
-    'buildReviewerPrompt#accessMode=tool-access#previousHead=present#unattended=true',
+    'buildReviewerPrompt#accessMode=read-only-inlined#earlierScopeChanges=present#previousHead=absent#unattended=false',
+    'buildReviewerPrompt#accessMode=read-only-inlined#earlierScopeChanges=present#previousHead=absent#unattended=true',
+    'buildReviewerPrompt#accessMode=read-only-inlined#earlierScopeChanges=present#previousHead=present#unattended=false',
+    'buildReviewerPrompt#accessMode=read-only-inlined#earlierScopeChanges=present#previousHead=present#unattended=true',
+    'buildReviewerPrompt#accessMode=read-only-tool#earlierScopeChanges=present#previousHead=absent#unattended=false',
+    'buildReviewerPrompt#accessMode=read-only-tool#earlierScopeChanges=present#previousHead=absent#unattended=true',
+    'buildReviewerPrompt#accessMode=read-only-tool#earlierScopeChanges=present#previousHead=present#unattended=false',
+    'buildReviewerPrompt#accessMode=read-only-tool#earlierScopeChanges=present#previousHead=present#unattended=true',
+    'buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=present#previousHead=absent#unattended=false',
+    'buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=present#previousHead=absent#unattended=true',
+    'buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=present#previousHead=present#unattended=false',
+    'buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=present#previousHead=present#unattended=true',
+    'buildReviewerPrompt#accessMode=read-only-inlined#earlierScopeChanges=absent#previousHead=absent#unattended=false',
+    'buildReviewerPrompt#accessMode=read-only-inlined#earlierScopeChanges=absent#previousHead=absent#unattended=true',
+    'buildReviewerPrompt#accessMode=read-only-inlined#earlierScopeChanges=absent#previousHead=present#unattended=false',
+    'buildReviewerPrompt#accessMode=read-only-inlined#earlierScopeChanges=absent#previousHead=present#unattended=true',
+    'buildReviewerPrompt#accessMode=read-only-tool#earlierScopeChanges=absent#previousHead=absent#unattended=false',
+    'buildReviewerPrompt#accessMode=read-only-tool#earlierScopeChanges=absent#previousHead=absent#unattended=true',
+    'buildReviewerPrompt#accessMode=read-only-tool#earlierScopeChanges=absent#previousHead=present#unattended=false',
+    'buildReviewerPrompt#accessMode=read-only-tool#earlierScopeChanges=absent#previousHead=present#unattended=true',
+    'buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=absent#previousHead=absent#unattended=false',
+    'buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=absent#previousHead=absent#unattended=true',
+    'buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=absent#previousHead=present#unattended=false',
+    'buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=absent#previousHead=present#unattended=true',
   ],
   completion_coder: ['buildFinalCompletionSummaryPrompt'],
   completion_reviewer: [
@@ -595,10 +622,10 @@ const EXPECTED_KEYS: Record<PromptSpecId, string[]> = {
 
 const EXPECTED_MODULE_SHAS: Record<(typeof MATRIX_BUILDER_MODULES)[number], string> = {
   'src/neal/prompts/planning.ts': '2a672e48c2e8cbe801435eeeacfb7fb18fd083c96055c50fdd2b076301e82c68',
-  'src/neal/prompts/execute.ts': 'e9f070b05fbbfea139c5c29ca9a3d2829d1a4f9acab43d31a7af0aee4b50aabd',
+  'src/neal/prompts/execute.ts': '37577b930caefb8c4274649f7ebbbece5195493bbf9a3744905a5163c12df5c4',
   'src/neal/prompts/specialized.ts': '3179bb3e735096d34c77be2ae10c9acb287b0f2ecc5e4994c158a1ed0e784e93',
   'src/neal/agents/prompts.ts': '41d989ceb0e4abe0e7fc99f05c4c50c3eb4f986e6c3294e24bda87bacd60e88c',
-  'src/neal/context/reviewer-context.ts': '71f9a651dd0b728cd50cf5bcbb9d7a260b98c8b1d28a8c414dd4ef0029f0d129',
+  'src/neal/context/reviewer-context.ts': '7168f61b26ff2c9fb9fa67ce7c608f452722fcfc5187f8c346910264a4c00674',
   'src/neal/context/inline-review-context.ts': 'a4a139c5c98ef81a88ebf203314444a1bb9c1d244d324ea14ebe000f5289c8b4',
 };
 
@@ -662,6 +689,7 @@ type AxisConformanceCase = { withKey: string; withoutKey: string; sentinel: stri
 const GIT_COMMANDS_SENTINEL = 'Use git commands against the repository';
 const GIT_DIFF_TOOL_SENTINEL = 'use the git_diff tool';
 const INLINED_RANGE_DIFF_SENTINEL = '## Inlined commit-range diff from Neal';
+const EARLIER_SCOPE_CHANGES_SENTINEL = '## Earlier-scope changes to files in this diff';
 
 const AXIS_CONFORMANCE: AxisConformanceCase[] = [
   // authoredOneShot
@@ -692,8 +720,8 @@ const AXIS_CONFORMANCE: AxisConformanceCase[] = [
     sentinel: UNATTENDED_AUTONOMY_PROMPT_LINE,
   },
   {
-    withKey: 'buildReviewerPrompt#accessMode=tool-access#previousHead=present#unattended=true',
-    withoutKey: 'buildReviewerPrompt#accessMode=tool-access#previousHead=present#unattended=false',
+    withKey: 'buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=absent#previousHead=present#unattended=true',
+    withoutKey: 'buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=absent#previousHead=present#unattended=false',
     sentinel: UNATTENDED_AUTONOMY_PROMPT_LINE,
   },
   {
@@ -701,10 +729,17 @@ const AXIS_CONFORMANCE: AxisConformanceCase[] = [
     withoutKey: 'buildFinalCompletionReviewerPrompt#accessMode=tool-access#aggregateRange=available#unattended=false',
     sentinel: UNATTENDED_AUTONOMY_PROMPT_LINE,
   },
+  // earlierScopeChanges present/absent on buildReviewerPrompt: the section
+  // renders only with an overlap; the preservation rule renders either way.
+  {
+    withKey: 'buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=present#previousHead=present#unattended=false',
+    withoutKey: 'buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=absent#previousHead=present#unattended=false',
+    sentinel: EARLIER_SCOPE_CHANGES_SENTINEL,
+  },
   // previousHead
   {
-    withKey: 'buildReviewerPrompt#accessMode=tool-access#previousHead=present#unattended=false',
-    withoutKey: 'buildReviewerPrompt#accessMode=tool-access#previousHead=absent#unattended=false',
+    withKey: 'buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=absent#previousHead=present#unattended=false',
+    withoutKey: 'buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=absent#previousHead=absent#unattended=false',
     sentinel: 'Previous reviewer head was',
   },
   // terminalOnly / allowReplacement
@@ -747,18 +782,18 @@ const AXIS_CONFORMANCE: AxisConformanceCase[] = [
   },
   // buildReviewerPrompt access submodes
   {
-    withKey: 'buildReviewerPrompt#accessMode=tool-access#previousHead=present#unattended=false',
-    withoutKey: 'buildReviewerPrompt#accessMode=read-only-tool#previousHead=present#unattended=false',
+    withKey: 'buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=absent#previousHead=present#unattended=false',
+    withoutKey: 'buildReviewerPrompt#accessMode=read-only-tool#earlierScopeChanges=absent#previousHead=present#unattended=false',
     sentinel: GIT_COMMANDS_SENTINEL,
   },
   {
-    withKey: 'buildReviewerPrompt#accessMode=read-only-inlined#previousHead=present#unattended=false',
-    withoutKey: 'buildReviewerPrompt#accessMode=read-only-tool#previousHead=present#unattended=false',
+    withKey: 'buildReviewerPrompt#accessMode=read-only-inlined#earlierScopeChanges=absent#previousHead=present#unattended=false',
+    withoutKey: 'buildReviewerPrompt#accessMode=read-only-tool#earlierScopeChanges=absent#previousHead=present#unattended=false',
     sentinel: INLINED_RANGE_DIFF_SENTINEL,
   },
   {
-    withKey: 'buildReviewerPrompt#accessMode=read-only-tool#previousHead=present#unattended=false',
-    withoutKey: 'buildReviewerPrompt#accessMode=read-only-inlined#previousHead=present#unattended=false',
+    withKey: 'buildReviewerPrompt#accessMode=read-only-tool#earlierScopeChanges=absent#previousHead=present#unattended=false',
+    withoutKey: 'buildReviewerPrompt#accessMode=read-only-inlined#earlierScopeChanges=absent#previousHead=present#unattended=false',
     sentinel: GIT_DIFF_TOOL_SENTINEL,
   },
   // buildFinalCompletionReviewerPrompt access submodes (aggregate range available)
@@ -860,7 +895,7 @@ function registerTests(): void {
 
   test('reviewer access-mode branches render distinctly (both read-only submodes covered)', () => {
     const render = (accessMode: string, previousHead: string, unattended: string) =>
-      reviewerSpec.render({ accessMode, previousHead, unattended });
+      reviewerSpec.render({ accessMode, earlierScopeChanges: 'absent', previousHead, unattended });
     const toolAccess = render('tool-access', 'present', 'false');
     const readOnlyInlined = render('read-only-inlined', 'present', 'false');
     const readOnlyTool = render('read-only-tool', 'present', 'false');
@@ -894,8 +929,8 @@ function registerTests(): void {
   test('reviewer cells render production continuity framing and plan content per access mode', () => {
     // scope reviewer: every mode gets the tool-access citations framing (the
     // removed no-read inline framing must never render).
-    const scopeToolAccess = cellRenderByKey('buildReviewerPrompt#accessMode=tool-access#previousHead=present#unattended=false');
-    const scopeReadOnly = cellRenderByKey('buildReviewerPrompt#accessMode=read-only-inlined#previousHead=present#unattended=false');
+    const scopeToolAccess = cellRenderByKey('buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=absent#previousHead=present#unattended=false');
+    const scopeReadOnly = cellRenderByKey('buildReviewerPrompt#accessMode=read-only-inlined#earlierScopeChanges=absent#previousHead=present#unattended=false');
     for (const render of [scopeToolAccess, scopeReadOnly]) {
       assert.ok(render.includes('# Reviewer Continuity Context'), 'scope reviewer must render the continuity block');
       assert.ok(render.includes('Inspect cited artifacts'));
@@ -981,8 +1016,8 @@ function registerTests(): void {
       'buildScopePrompt#unattended=true',
       'buildBlockedRecoveryCoderPrompt#allowReplacement=false#terminalOnly=true',
       'buildBlockedRecoveryCoderPrompt#allowReplacement=true#terminalOnly=false',
-      'buildReviewerPrompt#accessMode=read-only-inlined#previousHead=present#unattended=false',
-      'buildReviewerPrompt#accessMode=read-only-tool#previousHead=present#unattended=false',
+      'buildReviewerPrompt#accessMode=read-only-inlined#earlierScopeChanges=absent#previousHead=present#unattended=false',
+      'buildReviewerPrompt#accessMode=read-only-tool#earlierScopeChanges=absent#previousHead=present#unattended=false',
       // New authored axes (R2-F1): planDocument, planReviewGuidance, aggregate-range.
       'buildPlanningPrompt#authoredOneShot=false#planDocument=present#unattended=false',
       'buildCoderPlanResponsePrompt#mode=blocking#planReviewGuidance=present#reviewMode=plan',

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -28,7 +28,7 @@ import {
   getReviewerCapability,
   validateAdjudicationSpecContracts,
 } from '../src/neal/adjudicator/specs.js';
-import { runExecuteReviewerAdjudication } from '../src/neal/adjudicator/execute.js';
+import { collectEarlierScopeChanges, runExecuteReviewerAdjudication } from '../src/neal/adjudicator/execute.js';
 import { clearConfigCache } from '../src/neal/config.js';
 import { CONFLICTING_OUTPUT_FORMAT_MARKERS } from '../src/neal/agents/structured-json.js';
 import { completionJsonOutputFormatLines } from '../src/neal/prompts/specialized.js';
@@ -3057,4 +3057,146 @@ test('scope review prompt reaching a read-only structured advisor instructs read
 
   assert.equal(result.reviewerResult.sessionHandle, null);
   assert.equal(result.reviewerResult.meaningfulProgress.action, 'accept');
+});
+
+// Issue #10: the reviewer session is the only long-lived memory across scopes,
+// and its record of an earlier scope is the coder's summary. When the current
+// diff touches a file an earlier accepted scope changed, the adjudicator hands
+// the reviewer that scope's per-file diff so the overlap is read, not recalled.
+test('execute reviewer adjudication inlines earlier accepted scopes\' per-file diffs for files the current diff touches again', async () => {
+  const { state } = await createState({
+    baseCommit: 'base600',
+    currentScopeNumber: 6,
+    currentScopeProgressJustification: {
+      milestoneTargeted: 'Scope 6 adjusts the shared helper.',
+      newEvidence: 'The scope commit touches the helper and its test.',
+      whyNotRedundant: 'Scope 6 work.',
+      nextStepUnlocked: 'The reviewer can adjudicate.',
+    },
+  });
+  const scope = (overrides: Partial<OrchestrationState['completedScopes'][number]>): OrchestrationState['completedScopes'][number] => ({
+    number: '1',
+    marker: 'AUTONOMY_SCOPE_DONE',
+    result: 'accepted',
+    baseCommit: 'base100',
+    finalCommit: 'final100',
+    summary: null,
+    commitSubject: null,
+    changedFiles: [],
+    reviewRounds: 1,
+    findings: 0,
+    residualReviewDebt: [],
+    archivedReviewPath: null,
+    blocker: null,
+    derivedFromParentScope: null,
+    replacedByDerivedPlanPath: null,
+    ...overrides,
+  });
+  state.completedScopes = [
+    // Accepted and overlapping on one file: included.
+    scope({ number: '3', baseCommit: 'base300', finalCommit: 'final300', changedFiles: ['src/helper.ts', 'src/unrelated.ts'] }),
+    // Blocked: skipped even though it overlaps.
+    scope({ number: '4', result: 'blocked', marker: 'AUTONOMY_BLOCKED', baseCommit: 'base400', finalCommit: null, changedFiles: ['src/helper.ts'] }),
+    // Replaced by a derived plan: its work was reset, so skipped.
+    scope({ number: '5', baseCommit: 'base500', finalCommit: 'final500', changedFiles: ['test/helper.test.ts'], replacedByDerivedPlanPath: '/tmp/DERIVED.md' }),
+    // Accepted, no overlap: nothing to inline.
+    scope({ number: '5b', baseCommit: 'base550', finalCommit: 'final550', changedFiles: ['src/elsewhere.ts'] }),
+  ];
+  const diffCalls: Array<{ base: string; head: string; paths: readonly string[] }> = [];
+  let received: unknown = undefined;
+
+  await runExecuteReviewerAdjudication({
+    state,
+    getHeadCommit: async () => 'head600',
+    getCommitRange: async () => ['head600 Adjust the shared helper'],
+    getDiffStatForRange: async () => '2 files changed',
+    getChangedFilesForRange: async () => ['src/helper.ts', 'test/helper.test.ts'],
+    getDiffForRange: async () => 'current scope diff',
+    getDiffForRangePaths: async (_cwd, base, head, paths) => {
+      diffCalls.push({ base, head, paths });
+      return `diff for ${paths.join(',')} in ${base}..${head}`;
+    },
+    runReviewerRound: async (args) => {
+      received = args.earlierScopeChanges;
+      return {
+        sessionHandle: null,
+        summary: 'Reviewed.',
+        findings: [],
+        meaningfulProgress: { action: 'accept', rationale: 'Advances the objective.' },
+      };
+    },
+  });
+
+  assert.deepEqual(diffCalls, [{ base: 'base300', head: 'final300', paths: ['src/helper.ts'] }]);
+  assert.deepEqual(received, [
+    {
+      file: 'src/helper.ts',
+      scopeNumber: '3',
+      baseCommit: 'base300',
+      finalCommit: 'final300',
+      diff: 'diff for src/helper.ts in base300..final300',
+    },
+  ]);
+});
+
+test('collectEarlierScopeChanges returns nothing and calls no git when no accepted scope overlaps', async () => {
+  const { state } = await createState({ baseCommit: 'base200' });
+  let calls = 0;
+  const changes = await collectEarlierScopeChanges({
+    state,
+    changedFiles: ['src/new.ts'],
+    getDiffForRangePaths: async () => {
+      calls += 1;
+      return 'unexpected';
+    },
+  });
+  assert.deepEqual(changes, []);
+  assert.equal(calls, 0);
+});
+
+// The prompt renders the earlier-scope section only with an overlap, and the
+// preservation rule in every case: a tool-access reviewer can find earlier
+// scope history itself, and the rule must not depend on Neal inlining it.
+test('scope reviewer prompt renders earlier-scope per-file diffs when supplied and the preservation rule always', () => {
+  const base = {
+    planDoc: '/tmp/PLAN.md',
+    baseCommit: 'base600',
+    headCommit: 'head600',
+    commits: ['head600 Adjust the shared helper'],
+    diffStat: '2 files changed',
+    changedFiles: ['src/helper.ts', 'test/helper.test.ts'],
+    round: 1,
+    reviewMarkdownPath: '/tmp/REVIEW.md',
+    parentScopeLabel: '6',
+    progressJustification: {
+      milestoneTargeted: 'm',
+      newEvidence: 'e',
+      whyNotRedundant: 'w',
+      nextStepUnlocked: 'n',
+    },
+    recentHistorySummary: 'none',
+    scratchDir: '/tmp/scratch',
+  };
+  const withOverlap = buildReviewerPrompt({
+    ...base,
+    earlierScopeChanges: [
+      {
+        file: 'src/helper.ts',
+        scopeNumber: '3',
+        baseCommit: 'base300',
+        finalCommit: 'final300',
+        diff: 'diff --git a/src/helper.ts b/src/helper.ts\n+assert.equal(result, 42);\n',
+      },
+    ],
+  });
+  const withoutOverlap = buildReviewerPrompt({ ...base, earlierScopeChanges: [] });
+
+  assert.match(withOverlap, /## Earlier-scope changes to files in this diff/);
+  assert.match(withOverlap, /### src\/helper\.ts \(scope 3, base300\.\.final300\)/);
+  assert.match(withOverlap, /\+assert\.equal\(result, 42\);/);
+  assert.doesNotMatch(withoutOverlap, /## Earlier-scope changes to files in this diff/);
+  for (const prompt of [withOverlap, withoutOverlap]) {
+    assert.match(prompt, /must preserve what that scope's review accepted/);
+    assert.match(prompt, /Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding/);
+  }
 });


### PR DESCRIPTION
## Summary

The scope reviewer's only memory of an earlier scope was the coder's summary, so a later scope could satisfy its own criteria by weakening something an earlier scope added and the reviewer had nothing to check it against. This gives the reviewer the earlier scope's per-file diff for any file the current diff touches again, plus the doctrine line that goes with it.

## Changes

- `getDiffForRangePaths` in `git.ts` (fixed argv, path-restricted range diff)
- `collectEarlierScopeChanges` in the execute adjudicator: accepted scopes only, skips derived-plan replacements and scopes without a commit range
- `buildReviewerPrompt`: "Earlier-scope changes to files in this diff" section (overlap only, bounded by the inline-section limit) and an always-on preservation doctrine line
- reviewer continuity packet lists each completed scope's `changedFiles` (capped, with count)
- `scope_reviewer` prompt spec v3, new golden, re-pinned module SHAs, new render axis
- tests for the git helper, adjudicator overlap rules, prompt rendering, and packet bound
- docs: `prompt-specs.md`, `storage.md`, CHANGELOG

Closes #10
