### PR TITLE
Prepare 0.4.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ dependency-update policy.
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-08-21
+
+### Changed
+
+- Updated `@openai/codex-sdk` from `0.147.0` to `0.148.0` and
+  `@anthropic-ai/claude-agent-sdk` from `0.3.234` to `0.3.235`. Re-qualified
+  both native adapters with `neal compat`; no behavior change.
+
 ## [0.4.0] - 2026-08-20
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@navels/neal",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "A source-first multi-agent CLI for planning, executing, reviewing, and resuming scoped code changes.",
   "license": "MIT",
   "publishConfig": {


### PR DESCRIPTION
## Summary

Release prep for 0.4.1, a patch release covering the qualified native SDK bumps from #15.

## Changes

- Bump `package.json.version` to 0.4.1
- Add the 0.4.1 changelog section: `@openai/codex-sdk` 0.147.0 -> 0.148.0, `@anthropic-ai/claude-agent-sdk` 0.3.234 -> 0.3.235 (re-qualified via `scripts/qualify-sdk.sh 15`)

All release gates pass locally: `validate:release` (dry run), typecheck, lint, test (1707 pass), build, `verify-package`.