### PR TITLE
Prepare 0.4.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ dependency-update policy.
 
 ## [Unreleased]
 
+## [0.4.2] - 2026-08-23
+
+### Changed
+
+- Updated `@anthropic-ai/claude-agent-sdk` from `0.3.235` to `0.3.237`.
+  Re-qualified the native adapter with `neal compat`; no behavior change.
+
 ## [0.4.1] - 2026-08-21
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@navels/neal",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "A source-first multi-agent CLI for planning, executing, reviewing, and resuming scoped code changes.",
   "license": "MIT",
   "publishConfig": {


### PR DESCRIPTION
## Summary

Release prep for 0.4.2, a patch release covering the qualified native SDK bump from #17.

## Changes

- Bump `package.json.version` to 0.4.2
- Add the 0.4.2 changelog section: `@anthropic-ai/claude-agent-sdk` 0.3.235 -> 0.3.237 (re-qualified via `scripts/qualify-sdk.sh 17`)

All release gates pass locally: `validate:release` (dry run), typecheck, lint, test (1707 pass), build, `verify-package`.