### PR TITLE
Prepare 0.4.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ dependency-update policy.
 
 ## [Unreleased]
 
+## [0.4.3] - 2026-08-24
+
+### Changed
+
+- Updated `@anthropic-ai/claude-agent-sdk` from `0.3.237` to `0.3.238` and `@openai/codex-sdk` from `0.148.0` to `0.149.0`. Re-qualified both native adapters with `neal compat`; no behavior change.
+
 ## [0.4.2] - 2026-08-23
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@navels/neal",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "A source-first multi-agent CLI for planning, executing, reviewing, and resuming scoped code changes.",
   "license": "MIT",
   "publishConfig": {


### PR DESCRIPTION
## Summary

Release prep for 0.4.3, a patch release covering the dependency bumps from #19.

## Changes

- Bump `package.json.version` to 0.4.3
- Add the 0.4.3 changelog section:

- Updated `@anthropic-ai/claude-agent-sdk` from `0.3.237` to `0.3.238` and `@openai/codex-sdk` from `0.148.0` to `0.149.0`. Re-qualified both native adapters with `neal compat`; no behavior change.

All release gates pass locally via scripts/release-sdk-bump.sh.