### PR TITLE
Prepare 0.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ dependency-update policy.
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-08-24
+
+### Changed
+
+- Updated `ai` from `7.0.65` to `7.0.73` and `@ai-sdk/openai-compatible` from
+  `3.0.30` to `3.0.34`.
+
 ### Removed
 
 - Removed unattended mode: the `--unattended` flag on `neal plan` /

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@navels/neal",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "description": "A source-first multi-agent CLI for planning, executing, reviewing, and resuming scoped code changes.",
   "license": "MIT",
   "publishConfig": {


### PR DESCRIPTION
## Summary

Release prep for 0.5.0, a minor release: the unattended-mode removal (#22, #23) plus the weekly AI-SDK bumps (#20).

## Changes

- Bump `package.json.version` to 0.5.0
- Move the Unreleased changelog content into a dated 0.5.0 section and add the `ai` 7.0.65 -> 7.0.73 / `@ai-sdk/openai-compatible` 3.0.30 -> 3.0.34 entry

All release gates pass locally: `validate:release` (dry run), typecheck, lint, test (1685 pass), build, `verify-package`.