### PR TITLE
Prepare 0.5.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ dependency-update policy.
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-08-24
+
+### Changed
+
+- Updated `@anthropic-ai/claude-agent-sdk` from `0.3.238` to `0.3.239`. Re-qualified the native adapter with `neal compat`; no behavior change.
+
 ## [0.5.0] - 2026-08-24
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@navels/neal",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "A source-first multi-agent CLI for planning, executing, reviewing, and resuming scoped code changes.",
   "license": "MIT",
   "publishConfig": {


### PR DESCRIPTION
## Summary

Release prep for 0.5.1, a patch release covering the dependency bumps from #25.

## Changes

- Bump `package.json.version` to 0.5.1
- Add the 0.5.1 changelog section:

- Updated `@anthropic-ai/claude-agent-sdk` from `0.3.238` to `0.3.239`. Re-qualified the native adapter with `neal compat`; no behavior change.

All release gates pass locally via scripts/release-sdk-bump.sh.