### PR TITLE
Raise final-completion continue-execution default from 2 to 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,9 @@ dependency-update policy.
   input and resume, rather than just saying to resume. Resume still runs and
   re-measures the prompt each time, so it works once the input is smaller (#28).
   See [docs/prompt-specs.md](docs/prompt-specs.md) for the prompt-size contract.
-
+- Raised the default `final_completion_continue_execution_max` from 2 to 3, so
+  the final-completion reviewer gets one more round to send the coder back
+  before a run blocks for the operator.
 ## [0.5.1] - 2026-08-24
 
 ### Changed

--- a/neal.yml
+++ b/neal.yml
@@ -40,7 +40,7 @@
 #
 #   # Maximum number of times final completion review may send execution back
 #   # for more work before neal stops reopening the plan.
-#   final_completion_continue_execution_max: 2
+#   final_completion_continue_execution_max: 3
 #
 #   # Optional local notification command. Leave commented to keep
 #   # notifications disabled.

--- a/src/neal/config.ts
+++ b/src/neal/config.ts
@@ -133,7 +133,7 @@ const DEFAULT_CONFIG: NealResolvedConfig = {
     agent_turn_startup_timeout_ms: 300_000,
     agent_turn_retry_limit: 1,
     interactive_blocked_recovery_max_turns: 3,
-    final_completion_continue_execution_max: 2,
+    final_completion_continue_execution_max: 3,
     consultant_max_attempts: 1,
     notify_bin: null,
   },


### PR DESCRIPTION
## Summary

Bumps the default `final_completion_continue_execution_max` from 2 to 3. After all scopes are accepted, the final-completion reviewer can send the coder back for more work this many times before the run blocks for the operator. Two was low — a run could exhaust it and block on a small, legitimate finding the coder could have fixed given one more pass (as happened on the #28 run). Three matches its sibling `interactive_blocked_recovery_max_turns`.

## Changes

- `src/neal/config.ts`: default 2 -> 3
- `neal.yml`: template comment updated
- CHANGELOG entry under Unreleased

Still a config knob; this only moves the default. Full suite green locally: typecheck, lint, 1685 tests, build, verify:package.