### PR TITLE
Prepare 0.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ dependency-update policy.
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-08-25
+
 ### Fixed
 
 - Final-completion review could exceed the reviewer provider's input limit
@@ -37,6 +39,9 @@ dependency-update policy.
 - Raised the default `final_completion_continue_execution_max` from 2 to 3, so
   the final-completion reviewer gets one more round to send the coder back
   before a run blocks for the operator.
+- Updated `@anthropic-ai/claude-agent-sdk` from `0.3.239` to `0.3.240`.
+  Re-qualified the native adapter with `neal compat`; no behavior change.
+
 ## [0.5.1] - 2026-08-24
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@navels/neal",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "A source-first multi-agent CLI for planning, executing, reviewing, and resuming scoped code changes.",
   "license": "MIT",
   "publishConfig": {


### PR DESCRIPTION
## Summary

Minor release. Batches the issue-28 prompt-size work (a behavior change, so minor not patch), the continue-execution default bump, and the qualified claude-agent-sdk update.

## Changes

- Bump `package.json.version` to 0.6.0
- Roll `## [Unreleased]` into `## [0.6.0]`: the final-completion prompt-size fix (#28), `final_completion_continue_execution_max` default 2 -> 3, and `@anthropic-ai/claude-agent-sdk` 0.3.239 -> 0.3.240 (qualified via `scripts/qualify-sdk.sh 30`)

All release gates pass locally: `validate:release` (dry run), typecheck, lint, test (1733 pass), build, `verify-package`.