### PR TITLE
Allow the terminal-resolution turn past the recovery cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ dependency-update policy.
   a side note. The coder never revises the current or an earlier scope, and a
   consultant-injected directive can't trigger it.
 
+### Fixed
+
+- A blocked run that exhausted the recovery turn cap and was then given a
+  terminal directive resolving to `terminal_block` no longer fails to save. The
+  terminal directive records one resolution turn past the cap, and the state
+  invariant now allows that single extra turn (#37).
+
 ## [0.6.0] - 2026-08-25
 
 ### Fixed

--- a/src/neal/state-invariants.ts
+++ b/src/neal/state-invariants.ts
@@ -295,11 +295,17 @@ function assertValidInteractiveBlockedRecoveryState(args: {
       `must not exceed recorded turn count ${recovery.turns.length}`,
     );
   }
-  if (recovery.turns.length > recovery.maxTurns) {
+  // A recovery that reaches the turn cap and is then resolved by a turn-cap
+  // terminal directive records one terminal-resolution turn beyond `maxTurns`,
+  // so the recorded count may be `maxTurns + 1`. That extra turn is only ever
+  // the terminal resolution: past the cap, new guidance becomes a
+  // `pendingDirective` rather than an appended turn, so nothing else can push
+  // the count higher.
+  if (recovery.turns.length > recovery.maxTurns + 1) {
     throwStateInvariant(
       context,
       `${fieldPath}.turns`,
-      `recorded turn count ${recovery.turns.length} exceeds maxTurns ${recovery.maxTurns}`,
+      `recorded turn count ${recovery.turns.length} exceeds maxTurns ${recovery.maxTurns} by more than the one terminal-resolution turn`,
     );
   }
 

--- a/test/orchestrator-recovery.test.ts
+++ b/test/orchestrator-recovery.test.ts
@@ -1811,6 +1811,75 @@ test('interactive blocked recovery can finalize into a terminal blocked run', as
   assert.match(supportMarkdown, /Recovery turn 1 coder action: terminal_block/);
 });
 
+test('a turn-cap terminal_block persists without tripping the recovery history turn-count invariant (#37)', async () => {
+  const { statePath, state } = await createResumeFixture({
+    currentScopeNumber: 4,
+    phase: 'interactive_blocked_recovery',
+    status: 'running',
+    blockedFromPhase: 'reviewer_scope',
+    coderSessionHandle: 'coder-session-4',
+    interactiveBlockedRecovery: {
+      enteredAt: '2026-05-01T00:00:00.000Z',
+      sourcePhase: 'reviewer_scope',
+      blockedReason: 'Review findings stopped converging.',
+      maxTurns: 3,
+      lastHandledTurn: 3,
+      pendingDirective: {
+        recordedAt: '2026-05-01T00:04:00.000Z',
+        operatorGuidance: 'Give up on this scope.',
+        terminalOnly: true,
+        origin: 'operator',
+      },
+      turns: [1, 2, 3].map((n) => ({
+        number: n,
+        recordedAt: `2026-05-01T00:0${n}:00.000Z`,
+        operatorGuidance: `Instruction ${n}.`,
+        origin: 'operator' as const,
+        disposition: {
+          recordedAt: `2026-05-01T00:0${n}:30.000Z`,
+          sessionHandle: 'coder-session-4',
+          action: 'resume_current_scope' as const,
+          summary: 'Continued.',
+          rationale: 'Operator input.',
+          blocker: '',
+          replacementPlan: '',
+          laterScopeNumber: 0,
+          laterScopeBody: '',
+          resultingPhase: 'coder_response' as const,
+        },
+      })),
+    },
+  });
+
+  // A turn-cap terminal_block records the terminal-resolution turn beyond the
+  // cap and archives the recovery; the persisted state must satisfy the history
+  // turn-count invariant, not throw.
+  const nextState = await applyInteractiveBlockedRecoveryDisposition(
+    state,
+    statePath,
+    {
+      action: 'terminal_block',
+      summary: 'Blocking for the operator.',
+      rationale: 'No safe way to continue.',
+      blocker: 'The scope cannot proceed without operator direction.',
+      replacementPlan: '',
+      laterScopeNumber: 0,
+      laterScopeBody: '',
+    },
+    'coder-session-4b',
+  );
+
+  assert.equal(nextState.phase, 'blocked');
+  assert.equal(nextState.status, 'blocked');
+  const archived = nextState.interactiveBlockedRecoveryHistory.at(-1);
+  assert.equal(archived?.resolvedByAction, 'terminal_block');
+  assert.equal(archived?.turns.length, 4);
+  assert.equal(archived?.turns.at(-1)?.origin, 'operator');
+
+  const reloaded = await loadState(statePath);
+  assert.equal(reloaded.interactiveBlockedRecoveryHistory.at(-1)?.turns.length, 4);
+});
+
 test('terminal blocked recovery abandons an active pending derived-plan review as rejected', async () => {
   const derivedPlanPath = '/tmp/DERIVED_PLAN_SCOPE_7.md';
   const { statePath, state } = await createResumeFixture({


### PR DESCRIPTION
## Summary

Fixes #37. A blocked run that exhausted the interactive-blocked-recovery turn cap and was then given a terminal directive resolving to `terminal_block` failed to save with `recorded turn count N exceeds maxTurns` — an unrecoverable dead end.

## Mechanism

Past the cap, new guidance becomes a `pendingDirective` rather than an appended turn, so `turns.length == maxTurns`. Resolving that directive with `terminal_block` routes through `withRecordedInteractiveBlockedRecoveryDisposition`, which appends the terminal-resolution turn (`maxTurns + 1`); `finalizeInteractiveBlockedRecovery` archives that recovery into `interactiveBlockedRecoveryHistory`, and `assertValidInteractiveBlockedRecoveryHistory` runs the `turns.length > maxTurns` check on the archived record, which throws.

## Fix

The state invariant now permits `maxTurns + 1` turns. That single extra turn is only ever the terminal resolution — once the cap is reached, further guidance becomes a `pendingDirective` instead of an appended turn, so nothing else can push the count higher; `maxTurns + 2` still fails. The terminal turn keeps its full disposition in history, so the audit stays consistent with normal turns.

## Changes

- `src/neal/state-invariants.ts` — the recovery turn-count check allows one terminal-resolution turn past the cap
- `test/orchestrator-recovery.test.ts` — regression: fill the cap, record a terminal directive, resolve with `terminal_block`, assert the state persists and archives the fourth turn
- CHANGELOG

Full suite green: typecheck, lint, 1760 tests, build, verify:package.