### PR TITLE
Configurable reviewer strictness (review_level)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,17 @@ dependency-update policy.
   plan, so the decision lands where the later scope runs against it instead of in
   a side note. The coder never revises the current or an earlier scope, and a
   consultant-injected directive can't trigger it.
+- `neal.review_level` (`strict | moderate | lenient`, default `moderate`) sets
+  how strict the scope and final-completion reviewers are about what rises to
+  a blocking finding. Under every level a blocking finding must be reachable
+  under the assumed trust boundaries, and `~/.neal/guidance/reviewer.md` can
+  widen or narrow those boundaries or demote and promote finding categories
+  without turning off the reachability filter, the adversarial stance, or
+  blocking on reachable correctness failures. Blank means unset; any other
+  unknown value fails `neal check`, fresh writer commands, and a `neal resume`
+  that is about to resume writer work, before any run state is touched or an
+  agent turn starts.
+  The `scope_reviewer` and `completion_reviewer` prompt-spec versions bumped.
 
 ## [0.6.0] - 2026-08-25
 

--- a/README.md
+++ b/README.md
@@ -453,6 +453,54 @@ agent:
     effort: xhigh
 ```
 
+### Review level
+
+`neal.review_level` sets how strict the scope reviewer and the final-completion
+reviewer are about what rises to a blocking finding. It takes one of three
+values and defaults to `moderate`:
+
+- `strict`: assume adversarial trust boundaries. Block on any failure reachable
+  under the worst case, including hardening gaps and missing defenses against
+  local or adversarial actors.
+- `moderate`: ordinary trust boundaries. Internal run artifacts aren't security
+  boundaries. Block on correctness bugs and failures reachable under normal use;
+  don't require defenses against an actor who could already subvert the system.
+- `lenient`: correctness and real, reachable bugs only. Minimal robustness,
+  style, or hardening demands.
+
+```yaml
+neal:
+  review_level: moderate
+```
+
+Set it in the repo's `neal.yml` or in `~/.neal/config.yml`; the repo value wins.
+A blank or null value means unset and falls back to `moderate`. Any other
+nonblank value (a typo, say) is rejected before any agent work: `neal check`
+fails, every fresh writer command fails at config load, and a `neal resume`
+that has selected a run and is about to resume writer work (plain, manual
+gate, or `--message`) fails before it takes the writer lock, rewrites run
+state, or starts an agent turn. Resume outcomes that never execute writer work
+(already done, already running, waiting for operator guidance) are decided
+first and don't validate the level.
+
+Under every level a blocking finding has to describe a failure that's actually
+reachable under the assumed trust boundaries, and the reviewer still treats the
+change as hostile input and tries to falsify it before crediting it. A level
+narrows what counts as blocking; it never means trust the coder or skip
+inspection. The plan reviewer, the consultant, and `neal review` don't use the
+level.
+
+`~/.neal/guidance/reviewer.md` refines the level rather than replacing it. It
+can widen or narrow the assumed trust boundaries ("we do defend the run
+directory against local processes" makes a local-process attack on the run
+directory blockable even at `moderate`) and it can demote or promote finding
+categories ("ignore performance, correctness only" makes a performance
+regression non-blocking at any level). It can't turn off the reachability
+filter, the adversarial stance, or blocking on reachable correctness failures,
+including correctness regressions. Guidance that conflicts with that floor is
+ignored on that point. See [Custom guidance](#custom-guidance) for where the
+file lives.
+
 ### Custom guidance
 
 neal supports additive guidance files for local preferences alongside the built-in protocol prompts:
@@ -462,6 +510,11 @@ neal supports additive guidance files for local preferences alongside the built-
 - `~/.neal/guidance/planner.md`
 
 Set `NEAL_GUIDANCE_DIR=/path/to/guidance` to load those same `coder.md`, `reviewer.md`, and `planner.md` files from another directory. neal records applied guidance roles, selected paths, and byte counts in run artifacts. Guidance contents stay out of terminal output.
+
+For the two code reviewers, `reviewer.md` layers on top of `neal.review_level`
+(see [Review level](#review-level)): it can adjust trust boundaries and finding
+categories, but it can't switch off the reachability filter or blocking on
+reachable correctness failures.
 
 ## Artifacts and storage
 

--- a/docs/prompt-specs.md
+++ b/docs/prompt-specs.md
@@ -361,6 +361,8 @@ testing or profile experiments. That override wins over the default directory.
 
 When present, the file contents are appended under a fixed `## User Guidance` section inside the built-in prompt. Structured output contracts, completion markers, and the canonical plan contract survive injection.
 
+In the scope reviewer and final-completion reviewer prompts, `## User Guidance` renders after the `neal.review_level` calibration lines (`getReviewLevelCalibrationLines` in [src/neal/prompts/review-doctrine.ts](../src/neal/prompts/review-doctrine.ts)). The level supplies the baseline trust boundaries and the default finding-severity rules; guidance may widen or narrow those boundaries and demote or promote finding categories, and the refined boundaries are what "reachable" means when the reviewer decides whether a finding blocks. Guidance can't remove the floor: the reachability filter, the adversarial stance, and blocking on reachable correctness failures (including correctness regressions) stay on at every level. The calibration text itself states this merge rule, so the precedence is rendered in the prompt rather than implied by section order.
+
 Diagnostics: when a neal writer run initializes or resumes, it logs which roles have guidance applied and the byte count to the run's `stderr.log` and as a `run.user_guidance_applied` / `run.user_guidance_scanned` event. That is enough to confirm a guidance file was picked up without dumping contents.
 
 Non-goals: no repo-local `.neal/guidance/` override, no full-prompt replacement, no per-scope guidance variants, and no substitution of built-in sections.

--- a/neal.yml
+++ b/neal.yml
@@ -42,6 +42,15 @@
 #   # for more work before neal stops reopening the plan.
 #   final_completion_continue_execution_max: 3
 #
+#   # How strict the scope and final-completion reviewers are about what
+#   # rises to a blocking finding. Under every level a blocking finding must
+#   # describe a failure reachable under the assumed trust boundaries.
+#   #   strict:   assume adversarial trust boundaries; block on hardening gaps
+#   #   moderate: ordinary trust boundaries; internal run artifacts are not
+#   #             security boundaries; block on correctness and normal-use bugs
+#   #   lenient:  correctness and real, reachable bugs only
+#   review_level: moderate
+#
 #   # Optional local notification command. Leave commented to keep
 #   # notifications disabled.
 #   # notify_bin: /absolute/path/to/notify

--- a/src/neal/agents/rounds.ts
+++ b/src/neal/agents/rounds.ts
@@ -6,6 +6,7 @@ import {
   getApiRetryLimit,
   getInactivityTimeoutMs,
 } from '../config.js';
+import { getReviewLevel } from '../config.js';
 import type { RunLogger } from '../logger.js';
 import { runWithAgentTurnLiveness } from '../providers/liveness.js';
 import { normalizeExecutionShapeDeclaration } from '../plan-validation.js';
@@ -339,7 +340,13 @@ export async function runReviewerRound(args: {
     cwd: args.cwd,
     // The doctrine access mode comes from the reviewer provider's declared
     // structured-advisor tool access, not from inline-context presence alone.
-    prompt: buildReviewerPrompt({ ...args, accessMode: getReviewerDoctrineAccessMode(args.reviewer) }),
+    // The review level comes from current config (`neal.review_level`), not
+    // persisted run state; the builder itself never reads config.
+    prompt: buildReviewerPrompt({
+      ...args,
+      accessMode: getReviewerDoctrineAccessMode(args.reviewer),
+      reviewLevel: getReviewLevel(args.cwd),
+    }),
     schema,
     structuredJsonProtocol: buildStructuredJsonProtocolSpec({
       schemaLabel: 'reviewer_payload',
@@ -555,7 +562,13 @@ export async function runReviewerFinalCompletionRound(args: {
     cwd: args.cwd,
     // The doctrine access mode comes from the reviewer provider's declared
     // structured-advisor tool access, not from inline-context presence alone.
-    prompt: buildFinalCompletionReviewerPrompt({ ...args, accessMode: getReviewerDoctrineAccessMode(args.reviewer) }),
+    // The review level comes from current config (`neal.review_level`), not
+    // persisted run state; the builder itself never reads config.
+    prompt: buildFinalCompletionReviewerPrompt({
+      ...args,
+      accessMode: getReviewerDoctrineAccessMode(args.reviewer),
+      reviewLevel: getReviewLevel(args.cwd),
+    }),
     schema,
     structuredJsonProtocol: buildStructuredJsonProtocolSpec({
       schemaLabel: 'final_completion_reviewer_payload',

--- a/src/neal/commands/check.ts
+++ b/src/neal/commands/check.ts
@@ -15,6 +15,7 @@ import {
   getMaxReviewRounds,
   getNotifyBin,
   getPhaseHeartbeatMs,
+  getReviewLevel,
   getReviewStuckWindow,
 } from '../config.js';
 import { getNealDirGitIgnoreStatus } from '../git.js';
@@ -130,6 +131,7 @@ function validateConfig(cwd: string) {
   getInteractiveBlockedRecoveryMaxTurns(cwd);
   getFinalCompletionContinueExecutionMax(cwd);
   getNotifyBin(cwd);
+  getReviewLevel(cwd);
 
   return agentConfig;
 }

--- a/src/neal/commands/resume-run.ts
+++ b/src/neal/commands/resume-run.ts
@@ -3,7 +3,7 @@ import { readdir, stat } from 'node:fs/promises';
 import { basename, join } from 'node:path';
 
 import { parseResumeArgs } from '../cli.js';
-import { assertWriterProvidersConfigured } from '../config.js';
+import { assertWriterProvidersConfigured, getReviewLevel } from '../config.js';
 import { writeDiagnostic } from '../diagnostic.js';
 import { assertGitRepositoryWithCommit } from '../git.js';
 import { loadOrInitialize } from '../orchestrator.js';
@@ -373,6 +373,12 @@ async function withResumeWriterLock<T extends ResumeRunOutcome>(
   evidence: ResumeLockEvidence,
   action: () => Promise<T>,
 ): Promise<T | ResumeAlreadyRunningOutcome> {
+  // Every path that resumes writer work (plain, manual gate, --message) goes
+  // through this seam. The review level is read from current config, not
+  // persisted run state, so it is validated here before the lock is taken or
+  // any run state is rewritten. No-op and rejection outcomes (done, already
+  // running, waiting for guidance) are decided earlier and never reach it.
+  getReviewLevel(selection.state.cwd);
   let lock: ActiveRunLockHandle;
   try {
     lock = await acquireResumeWriterLock(selection, evidence);

--- a/src/neal/config.ts
+++ b/src/neal/config.ts
@@ -24,6 +24,7 @@ export type NealConfigFile = {
     final_completion_continue_execution_max?: number | null;
     consultant_max_attempts?: number | null;
     notify_bin?: string | null;
+    review_level?: string | null;
   };
   agent?: {
     planner?: {
@@ -57,6 +58,10 @@ export type NealConfigFile = {
   };
 };
 
+export type ReviewLevel = 'strict' | 'moderate' | 'lenient';
+
+const REVIEW_LEVELS: readonly ReviewLevel[] = ['strict', 'moderate', 'lenient'];
+
 export type OpenAICompatibleSettings = {
   baseUrl: string | null;
   apiKeyEnv: string;
@@ -82,6 +87,7 @@ type NealResolvedConfig = {
     final_completion_continue_execution_max: number;
     consultant_max_attempts: number;
     notify_bin: string | null;
+    review_level: ReviewLevel;
   };
   agent: {
     planner: {
@@ -136,6 +142,7 @@ const DEFAULT_CONFIG: NealResolvedConfig = {
     final_completion_continue_execution_max: 3,
     consultant_max_attempts: 1,
     notify_bin: null,
+    review_level: 'moderate',
   },
   agent: {
     planner: {
@@ -232,6 +239,29 @@ function parseNumberValue(value: unknown): number | undefined {
 
 function parseStringValue(value: unknown): string | undefined {
   return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function isReviewLevel(value: string): value is ReviewLevel {
+  return (REVIEW_LEVELS as readonly string[]).includes(value);
+}
+
+function parseReviewLevelValue(value: unknown, fieldPath: string): ReviewLevel | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+
+  if (typeof value === 'string' && !value.trim()) {
+    return undefined;
+  }
+
+  const level = typeof value === 'string' ? value.trim() : value;
+  if (typeof level !== 'string' || !isReviewLevel(level)) {
+    throw new Error(
+      `Invalid review level for ${fieldPath}: ${JSON.stringify(level)}. Valid values: ${REVIEW_LEVELS.join(', ')}`,
+    );
+  }
+
+  return level;
 }
 
 function parseConfigProviderValue(value: unknown, fieldPath: string): AgentProvider | undefined {
@@ -417,7 +447,13 @@ export function assertWriterProvidersConfigured(
   }
 
   assertAgentConfigSupportsWriterRun(agentConfig, { context: options.context });
+  getReviewLevel(cwd);
   return agentConfig;
+}
+
+export function getReviewLevel(cwd = process.cwd()): ReviewLevel {
+  const config = loadConfigFile(cwd);
+  return parseReviewLevelValue(config.neal?.review_level, 'neal.review_level') ?? DEFAULT_CONFIG.neal.review_level;
 }
 
 export function getInactivityTimeoutMs(cwd = process.cwd()) {

--- a/src/neal/prompts/execute.ts
+++ b/src/neal/prompts/execute.ts
@@ -31,9 +31,11 @@ import {
   getFindingQualityLines,
   getPreexistingFailureContractLines,
   getRegressionPreservationLines,
+  getReviewLevelCalibrationLines,
   getVerificationSkepticismLines,
   type ReviewDoctrineAccessMode,
 } from './review-doctrine.js';
+import type { ReviewLevel } from '../config.js';
 
 const PROMPT_MODULE_PATH = 'src/neal/prompts/execute.ts' as const;
 
@@ -217,6 +219,9 @@ export function buildReviewerPrompt(args: {
   earlierScopeChanges?: readonly EarlierScopeFileChange[] | null;
   // Explicit reviewer doctrine access mode. Defaults to 'tool-access'.
   accessMode?: ReviewDoctrineAccessMode;
+  // Reviewer strictness from `neal.review_level`, resolved by rounds.ts via
+  // getReviewLevel(cwd). Defaults to 'moderate'.
+  reviewLevel?: ReviewLevel;
 }) {
   const spec = assertPromptBuilder('scope_reviewer', 'buildReviewerPrompt', PROMPT_MODULE_PATH);
   const primaryVariant = spec.variants.find((variant) => variant.kind === 'primary');
@@ -226,6 +231,7 @@ export function buildReviewerPrompt(args: {
   }
 
   const accessMode = args.accessMode ?? 'tool-access';
+  const reviewLevel = args.reviewLevel ?? 'moderate';
   // A collected diff may legitimately be the empty string (a range with no
   // changes); distinguish "collected" (any string, including '') from "not
   // collected" (null/undefined) so an empty diff still rides the inlined channel
@@ -277,8 +283,9 @@ export function buildReviewerPrompt(args: {
     ...getAdversarialReviewDoctrineLines({
       reviewSubject: 'the scope diff',
     }),
+    ...getReviewLevelCalibrationLines({ level: reviewLevel, outputContract: 'structured_findings' }),
     '',
-    ...getFindingQualityLines(),
+    ...getFindingQualityLines({ outputContract: 'structured_findings', level: reviewLevel }),
     ...skepticismLines,
     ...regressionLines,
     EARLIER_SCOPE_PRESERVATION_LINE,

--- a/src/neal/prompts/review-doctrine.ts
+++ b/src/neal/prompts/review-doctrine.ts
@@ -1,3 +1,5 @@
+import type { ReviewLevel } from '../config.js';
+
 export type AdversarialReviewDoctrineContext = {
   reviewSubject: string;
   falsificationTarget?: string;
@@ -40,9 +42,21 @@ export type VerificationSkepticismContext = {
   mode?: ReviewDoctrineAccessMode;
 };
 
+type ReviewOutputContract = 'structured_findings' | 'completion_verdict';
+
 export type FindingQualityContext = {
-  outputContract?: 'structured_findings' | 'completion_verdict';
+  outputContract?: ReviewOutputContract;
+  // Reviewer strictness from `neal.review_level`; threaded in by the builder,
+  // never read from config here. Defaults to 'moderate'.
+  level?: ReviewLevel;
 };
+
+type ReviewLevelCalibrationContext = {
+  level: ReviewLevel;
+  outputContract?: ReviewOutputContract;
+};
+
+const DEFAULT_REVIEW_LEVEL: ReviewLevel = 'moderate';
 
 export type RegressionPreservationContext = {
   reviewTarget?: string;
@@ -169,11 +183,51 @@ export function getPreexistingFailureContractLines(context: PreexistingFailureCo
   ];
 }
 
+function getReviewLevelTrustBoundaryLine(level: ReviewLevel) {
+  switch (level) {
+    case 'strict':
+      return 'Review level: strict. Assume adversarial trust boundaries: treat every input, file, and process the change can be reached from, including local processes and internal run artifacts, as a potential attacker. A hardening gap or a missing defense against a local or adversarial actor is a reachable failure under these boundaries and blocks.';
+    case 'lenient':
+      return 'Review level: lenient. Assume ordinary trust boundaries and block only on correctness failures and real, reachable bugs. Do not demand additional robustness, hardening, performance, or style work as a condition of acceptance.';
+    case 'moderate':
+      return 'Review level: moderate. Assume ordinary trust boundaries: internal run artifacts and other files this system writes for itself are not security boundaries. Block on correctness bugs and on failures reachable under normal use. Do not require defenses against an actor who could already subvert the system directly, for example by editing its files; a failure that needs such an actor is not reachable.';
+  }
+}
+
+function getDemotedCategoryMeaning(outputContract: ReviewOutputContract) {
+  return outputContract === 'completion_verdict'
+    ? 'In this review a demoted or ignored category is not missing work: it must not produce `continue_execution` or `block_for_operator`, and when the plan objectives are otherwise satisfied you return `accept_complete`.'
+    : 'In this review a demoted category means non_blocking severity, and an ignored category produces no finding.';
+}
+
+// Level calibration for the two code reviewers. Renders the level's assumed
+// trust boundaries, the reachability filter that applies under every level,
+// and the rule for how the User Guidance section refines the level. The adversarial
+// inspection stance itself is not level-dependent and is stated as such.
+export function getReviewLevelCalibrationLines(context: ReviewLevelCalibrationContext) {
+  const outputContract = context.outputContract ?? 'structured_findings';
+  const performanceExampleOutcome =
+    outputContract === 'completion_verdict' ? 'not missing work' : 'non_blocking';
+
+  return [
+    getReviewLevelTrustBoundaryLine(context.level),
+    'Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.',
+    'The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.',
+    'How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.',
+    `Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. ${getDemotedCategoryMeaning(outputContract)}`,
+    'Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.',
+    'Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.',
+    `Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression ${performanceExampleOutcome}, while a reachable correctness failure still blocks.`,
+  ];
+}
+
 export function getFindingQualityLines(context: FindingQualityContext = {}) {
+  const level = context.level ?? DEFAULT_REVIEW_LEVEL;
   if (context.outputContract === 'completion_verdict') {
     return [
       'Treat completion-blocking issues like review findings: each one needs concrete evidence, affected files or runtime behavior, and a required correction.',
       'Use `continue_execution` only for concrete missing work that is bounded enough for one follow-on scope; use `block_for_operator` for ambiguous or externally constrained gaps.',
+      'A finding category that the review level or the User Guidance section has demoted or ignored is not missing work: never return `continue_execution` or `block_for_operator` for it. When the plan objectives are otherwise satisfied, return `accept_complete`.',
       'Do not turn low-signal style preferences, trivial code-shape preferences, or optional refactors into missing work.',
       'If the plan is complete aside from low-signal trivia, return `accept_complete` rather than inventing a non-blocking completion concern.',
     ];
@@ -182,7 +236,9 @@ export function getFindingQualityLines(context: FindingQualityContext = {}) {
   return [
     'Produce only structured review findings.',
     'Use blocking severity for correctness, regression, or missing-verification issues.',
-    'Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.',
+    level === 'lenient'
+      ? 'Robustness or performance regressions introduced by the implementation are non_blocking unless they are a reachable correctness failure; use blocking severity only in that case.'
+      : 'Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.',
     'Use non_blocking severity for suggestions that do not block acceptance.',
     'Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.',
     'Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.',

--- a/src/neal/prompts/specialized.ts
+++ b/src/neal/prompts/specialized.ts
@@ -18,9 +18,11 @@ import {
   getFindingQualityLines,
   getPreexistingFailureContractLines,
   getRegressionPreservationLines,
+  getReviewLevelCalibrationLines,
   getVerificationSkepticismLines,
   type ReviewDoctrineAccessMode,
 } from './review-doctrine.js';
+import type { ReviewLevel } from '../config.js';
 
 const PROMPT_MODULE_PATH = 'src/neal/prompts/specialized.ts' as const;
 
@@ -188,6 +190,9 @@ export function buildFinalCompletionReviewerPrompt(args: {
   inlinedRangeDiff?: string | null;
   // Explicit reviewer doctrine access mode. Defaults to 'tool-access'.
   accessMode?: ReviewDoctrineAccessMode;
+  // Reviewer strictness from `neal.review_level`, resolved by rounds.ts via
+  // getReviewLevel(cwd). Defaults to 'moderate'.
+  reviewLevel?: ReviewLevel;
 }) {
   const spec = assertPromptBuilder('completion_reviewer', 'buildFinalCompletionReviewerPrompt', PROMPT_MODULE_PATH);
   const finalCompletionVariant = spec.variants.find((variant) => variant.kind === 'final_completion');
@@ -196,6 +201,7 @@ export function buildFinalCompletionReviewerPrompt(args: {
   }
 
   const accessMode = args.accessMode ?? 'tool-access';
+  const reviewLevel = args.reviewLevel ?? 'moderate';
   // A collected diff may legitimately be the empty string (a range with no
   // changes); distinguish "collected" (any string, including '') from "not
   // collected" (null/undefined) so an empty diff still rides the inlined channel
@@ -257,6 +263,7 @@ export function buildFinalCompletionReviewerPrompt(args: {
       judgmentTarget: 'whole-plan completion',
       proofTarget: 'the aggregate implementation satisfies the plan',
     }),
+    ...getReviewLevelCalibrationLines({ level: reviewLevel, outputContract: 'completion_verdict' }),
     ...falsificationLines,
     ...scratchLines,
     'Falsify cross-scope runtime invariants and integration behavior before accepting completion, especially paths that individual scope reviews could not see together.',
@@ -264,7 +271,7 @@ export function buildFinalCompletionReviewerPrompt(args: {
     ...skepticismLines,
     ...regressionLines,
     ...preexistingLines,
-    ...getFindingQualityLines({ outputContract: 'completion_verdict' }),
+    ...getFindingQualityLines({ outputContract: 'completion_verdict', level: reviewLevel }),
     'Review the whole-plan result for correctness and completeness against the plan objectives, regressions or missing behavior, cross-scope integration issues that may not have been visible in individual scope reviews, code quality, maintainability, and consistency of the final implementation, and adequacy of test coverage and verification for the total change.',
     ...getReviewerContextLines(args.reviewerContext),
     'Do not treat prior per-scope acceptance as sufficient evidence that the whole plan is complete or that the aggregate code quality is acceptable.',

--- a/src/neal/prompts/specs.ts
+++ b/src/neal/prompts/specs.ts
@@ -202,6 +202,13 @@ const SCOPE_REVIEWER_CONTEXT = context('ScopeReviewerPromptContext', [
     false,
     "Two-way reviewer doctrine access mode derived from the reviewer provider's structured-advisor tool access: 'tool-access' (inspect and execute) or 'read-only' (read tools only; no command execution, test runs, or scratch work). Defaults to 'tool-access' when absent.",
   ),
+
+  field(
+    'reviewLevel',
+    'orchestrator_state',
+    false,
+    "Reviewer strictness ('strict', 'moderate', or 'lenient') from the `neal.review_level` config key, resolved by rounds.ts via getReviewLevel(cwd). Defaults to 'moderate' when absent.",
+  ),
 ]);
 
 const COMPLETION_CODER_CONTEXT = context('CompletionCoderPromptContext', [
@@ -221,6 +228,13 @@ const COMPLETION_REVIEWER_CONTEXT = context('CompletionReviewerPromptContext', [
     'orchestrator_state',
     false,
     "Two-way reviewer doctrine access mode derived from the reviewer provider's structured-advisor tool access: 'tool-access' (inspect and execute) or 'read-only' (read tools only; no command execution, test runs, or scratch work). Defaults to 'tool-access' when absent.",
+  ),
+
+  field(
+    'reviewLevel',
+    'orchestrator_state',
+    false,
+    "Reviewer strictness ('strict', 'moderate', or 'lenient') from the `neal.review_level` config key, resolved by rounds.ts via getReviewLevel(cwd). Defaults to 'moderate' when absent.",
   ),
 ]);
 
@@ -563,7 +577,7 @@ export const PROMPT_SPECS: readonly PromptSpec[] = [
   },
   {
     id: 'scope_reviewer',
-    version: 4,
+    version: 5,
     changelog: [
       {
         version: 1,
@@ -580,6 +594,10 @@ export const PROMPT_SPECS: readonly PromptSpec[] = [
       {
         version: 4,
         renderSha: 'da87b19f2401ffdca21e3cefec1037c6470b3e74810b6152d07c55fa4924047f',
+      },
+      {
+        version: 5,
+        renderSha: 'e8dcb976d0ea22e9026e09a87d7dde93c8513334f62ad89472ebefe91771754b',
       },
     ],
     role: 'reviewer',
@@ -647,6 +665,12 @@ export const PROMPT_SPECS: readonly PromptSpec[] = [
               'orchestrator_state',
               false,
               "Optional explicit doctrine access mode ('tool-access' or 'read-only'); defaults to 'tool-access' when absent.",
+            ),
+            field(
+              'reviewLevel',
+              'orchestrator_state',
+              false,
+              "Optional reviewer strictness ('strict', 'moderate', or 'lenient') from `neal.review_level`, resolved by rounds.ts via getReviewLevel(cwd); defaults to 'moderate' when absent.",
             ),
           ]),
         },
@@ -747,7 +771,7 @@ export const PROMPT_SPECS: readonly PromptSpec[] = [
   },
   {
     id: 'completion_reviewer',
-    version: 4,
+    version: 5,
     changelog: [
       {
         version: 1,
@@ -764,6 +788,10 @@ export const PROMPT_SPECS: readonly PromptSpec[] = [
       {
         version: 4,
         renderSha: 'c47009016178fc29c34440e06636ba7b21c6beb59202dd3fe63e365cb32a75cf',
+      },
+      {
+        version: 5,
+        renderSha: '7930cec95560ad880bba94a7ae48e68c621805787261e295c4c405d09235c87b',
       },
     ],
     role: 'reviewer',
@@ -815,6 +843,12 @@ export const PROMPT_SPECS: readonly PromptSpec[] = [
               'orchestrator_state',
               false,
               "Optional explicit doctrine access mode ('tool-access' or 'read-only'); defaults to 'tool-access' when absent.",
+            ),
+            field(
+              'reviewLevel',
+              'orchestrator_state',
+              false,
+              "Optional reviewer strictness ('strict', 'moderate', or 'lenient') from `neal.review_level`, resolved by rounds.ts via getReviewLevel(cwd); defaults to 'moderate' when absent.",
             ),
           ]),
         },

--- a/test/adjudicator-final-completion.test.ts
+++ b/test/adjudicator-final-completion.test.ts
@@ -441,3 +441,19 @@ test('final-completion prompt for a native read-only structured advisor omits th
   assert.match(prompt, /treat the missing aggregate range as a completion-review evidence gap/);
   assert.doesNotMatch(prompt, /## Inlined review context from Neal/);
 });
+
+test('final-completion round resolves neal.review_level from the repository config and passes it to the built prompt', async () => {
+  const { state, baseCommit, headCommit } = await createFinalCompletionCaptureFixture('anthropic-claude');
+  await writeFile(join(state.cwd, 'neal.yml'), 'neal:\n  notify_bin: /usr/bin/true\n  review_level: lenient\n', 'utf8');
+  clearConfigCache(state.cwd);
+  const captured = installCapturingFinalCompletionAdvisor('anthropic-claude');
+  const packet = createCapturePacket({ baseCommit, headCommit, unavailableReason: null });
+
+  await runFinalCompletionReviewerAdjudication({ state, packet });
+
+  assert.equal(captured.length, 1);
+  const prompt = captured[0]!.prompt;
+  assert.match(prompt, /Review level: lenient\./);
+  assert.doesNotMatch(prompt, /Review level: moderate\./);
+  assert.match(prompt, /A finding category that the review level or the User Guidance section has demoted or ignored is not missing work/);
+});

--- a/test/check.test.ts
+++ b/test/check.test.ts
@@ -197,6 +197,36 @@ test('neal check validates config and skips provider verification in non-interac
   });
 });
 
+test('neal check fails on an invalid review_level before provider verification', async () => {
+  await withIsolatedHome(async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'neal-check-review-level-'));
+    await writeFile(
+      join(cwd, 'neal.yml'),
+      [
+        'neal:',
+        '  review_level: paranoid',
+        'agent:',
+        '  coder:',
+        '    provider: anthropic-claude',
+        '  reviewer:',
+        '    provider: anthropic-claude',
+        '',
+      ].join('\n'),
+      'utf8',
+    );
+    clearConfigCache(cwd);
+
+    await assert.rejects(
+      runNealCheckCli({
+        cwd,
+        stdin: createClosedInput(false),
+        stdout: new CaptureStream(),
+      }),
+      /Invalid review level for neal\.review_level: "paranoid"\. Valid values: strict, moderate, lenient/,
+    );
+  });
+});
+
 test('neal check does not print the compat pointer for a native writer provider', async () => {
   await withIsolatedHome(async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'neal-check-native-pointer-'));

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -17,6 +17,7 @@ import {
   getPlanReviewDebtRoundThreshold,
   getRawMergedConfig,
   getConsultantMaxAttempts,
+  getReviewLevel,
   getReviewStuckWindow,
   isWriterProvidersNotConfiguredError,
 } from '../src/neal/config.js';
@@ -248,6 +249,89 @@ test('repo config can disable a user notification helper', async () => {
 
     assert.equal(getRawMergedConfig(cwd).neal?.notify_bin, null);
     assert.equal(getNotifyBin(cwd), null);
+  });
+});
+
+test('getReviewLevel defaults to moderate and resolves each valid value', async () => {
+  await withIsolatedHome(async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'neal-config-review-level-'));
+    clearConfigCache(cwd);
+    assert.equal(getReviewLevel(cwd), 'moderate');
+
+    for (const level of ['strict', 'moderate', 'lenient'] as const) {
+      await writeFile(join(cwd, 'neal.yml'), `neal:\n  review_level: ${level}\n`, 'utf8');
+      clearConfigCache(cwd);
+      assert.equal(getReviewLevel(cwd), level);
+    }
+
+    await writeFile(join(cwd, 'neal.yml'), 'neal:\n  review_level: "  "\n', 'utf8');
+    clearConfigCache(cwd);
+    assert.equal(getReviewLevel(cwd), 'moderate');
+
+    await writeFile(join(cwd, 'neal.yml'), 'neal:\n  review_level: null\n', 'utf8');
+    clearConfigCache(cwd);
+    assert.equal(getReviewLevel(cwd), 'moderate');
+  });
+});
+
+test('getReviewLevel rejects unknown values naming the field path and valid set', async () => {
+  await withIsolatedHome(async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'neal-config-review-level-invalid-'));
+    await writeFile(join(cwd, 'neal.yml'), 'neal:\n  review_level: paranoid\n', 'utf8');
+    clearConfigCache(cwd);
+
+    assert.throws(
+      () => getReviewLevel(cwd),
+      /Invalid review level for neal\.review_level: "paranoid"\. Valid values: strict, moderate, lenient/,
+    );
+
+    await writeFile(join(cwd, 'neal.yml'), 'neal:\n  review_level: 3\n', 'utf8');
+    clearConfigCache(cwd);
+    assert.throws(
+      () => getReviewLevel(cwd),
+      /Invalid review level for neal\.review_level: 3\. Valid values: strict, moderate, lenient/,
+    );
+  });
+});
+
+test('repo review_level overrides user review_level', async () => {
+  await withIsolatedHome(async (home) => {
+    const cwd = await mkdtemp(join(tmpdir(), 'neal-config-review-level-precedence-'));
+    await writeUserConfig(home, 'neal:\n  review_level: strict\n');
+    clearConfigCache(cwd);
+    assert.equal(getReviewLevel(cwd), 'strict');
+
+    await writeFile(join(cwd, 'neal.yml'), 'neal:\n  review_level: lenient\n', 'utf8');
+    clearConfigCache(cwd);
+    assert.equal(getReviewLevel(cwd), 'lenient');
+  });
+});
+
+test('assertWriterProvidersConfigured rejects an invalid review_level and accepts valid or unset values', async () => {
+  await withIsolatedHome(async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'neal-config-assert-review-level-'));
+    const writerConfig = (reviewLevelLine: string | null) => [
+      ...(reviewLevelLine === null ? [] : ['neal:', `  review_level: ${reviewLevelLine}`]),
+      'agent:',
+      '  coder:',
+      '    provider: openai-codex',
+      '  reviewer:',
+      '    provider: anthropic-claude',
+      '',
+    ].join('\n');
+
+    await writeFile(join(cwd, 'neal.yml'), writerConfig('bogus'), 'utf8');
+    clearConfigCache(cwd);
+    assert.throws(
+      () => assertWriterProvidersConfigured(cwd),
+      /Invalid review level for neal\.review_level: "bogus"\. Valid values: strict, moderate, lenient/,
+    );
+
+    for (const reviewLevelLine of ['strict', null]) {
+      await writeFile(join(cwd, 'neal.yml'), writerConfig(reviewLevelLine), 'utf8');
+      clearConfigCache(cwd);
+      assert.equal(assertWriterProvidersConfigured(cwd).coder.provider, 'openai-codex');
+    }
   });
 });
 

--- a/test/fixtures/prompts/render-integrity/completion_reviewer.v5.txt
+++ b/test/fixtures/prompts/render-integrity/completion_reviewer.v5.txt
@@ -1,0 +1,2610 @@
+=== buildFinalCompletionReviewerPrompt#accessMode=read-only-inlined#aggregateRange=available#reviewLevel=lenient ===
+Review whether the execute-mode plan at /tmp/PLAN.md is complete as a whole.
+
+This is a whole-plan final completion review, not an ordinary last-scope review.
+Compare the completed result against the original plan objectives and the whole-plan completion packet below.
+Evaluate the totality of the work completed for this plan, not just whether each individual scope was previously accepted.
+Your review must answer both of these questions:
+- Are the full plan objectives actually satisfied?
+- Is the aggregate implementation good enough to keep under ordinary code review standards?
+Treat the whole-plan completion claim as hostile input. Try to falsify the aggregate implementation before you accept completion.
+Do not anchor on the coder completion summary, completion packet, verification summaries, or prior per-scope acceptance history when judging whole-plan completion. Those are convergence signals, not proof that the aggregate implementation satisfies the plan.
+Review level: lenient. Assume ordinary trust boundaries and block only on correctness failures and real, reachable bugs. Do not demand additional robustness, hardening, performance, or style work as a condition of acceptance.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted or ignored category is not missing work: it must not produce `continue_execution` or `block_for_operator`, and when the plan objectives are otherwise satisfied you return `accept_complete`.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression not missing work, while a reachable correctness failure still blocks.
+The commit-range diff for that aggregate range base000..head000 is inlined below and is the source of truth for exactly what the aggregate range base000..head000 changed (including deletions and renames). Use your read tools to verify the surrounding code; you have no commit-range diff tool, so rely on the inlined diff for what changed.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Inspect the change using the inlined commit-range diff below for what changed (including deletions and renames), then read the changed files in full with your read tools and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the aggregate implementation; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Falsify cross-scope runtime invariants and integration behavior before accepting completion, especially paths that individual scope reviews could not see together.
+If `aggregateReviewContext.unavailableReason` is non-null, treat the missing aggregate range as a completion-review evidence gap rather than proof that the aggregate implementation is correct.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the aggregate implementation.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the aggregate implementation touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the aggregate implementation actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the aggregate implementation.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Treat completion-blocking issues like review findings: each one needs concrete evidence, affected files or runtime behavior, and a required correction.
+Use `continue_execution` only for concrete missing work that is bounded enough for one follow-on scope; use `block_for_operator` for ambiguous or externally constrained gaps.
+A finding category that the review level or the User Guidance section has demoted or ignored is not missing work: never return `continue_execution` or `block_for_operator` for it. When the plan objectives are otherwise satisfied, return `accept_complete`.
+Do not turn low-signal style preferences, trivial code-shape preferences, or optional refactors into missing work.
+If the plan is complete aside from low-signal trivia, return `accept_complete` rather than inventing a non-blocking completion concern.
+Review the whole-plan result for correctness and completeness against the plan objectives, regressions or missing behavior, cross-scope integration issues that may not have been visible in individual scope reviews, code quality, maintainability, and consistency of the final implementation, and adequacy of test coverage and verification for the total change.
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+Do not treat prior per-scope acceptance as sufficient evidence that the whole plan is complete or that the aggregate code quality is acceptable.
+Return only JSON that matches the required schema.
+Return the final answer only as the required structured output object, not as prose or markdown.
+Defer exact output framing to the active structured-output transport; do not add your own output-format constraints.
+Use `accept_complete` only when the full plan objectives are satisfied and the aggregate implementation is acceptable under ordinary code review standards.
+Use `continue_execution` only when the remaining work is concrete, bounded, and suitable for one explicit follow-on scope.
+Use `block_for_operator` when the remaining gap is ambiguous, externally constrained, or needs human direction.
+When you return `continue_execution`, you must provide a non-null `missingWork` object with `summary`, `requiredOutcome`, and `verification`.
+When you return any other action, `missingWork` must be null.
+
+Squash commit message rules:
+- `squashCommitMessage` is project-facing Git history for human readers.
+- Use `squashCommitMessage` only for `accept_complete`; when you return any non-accept action, set `squashCommitMessage` to null.
+- For `accept_complete`, provide a non-null object with one concise project-facing `subject` and 2 to 5 high-level `bullets`.
+- Do not mention plan paths, markdown plan filenames, temporary run paths, scope-numbered or per-scope wording, final cleanup, Neal mechanics, provider process, or reviewer process.
+- Summarize the code or product behavior change, not the plan document.
+- Valid example: subject "Persist final completion review failures"; bullets ["Mark invalid verdicts failed", "Record phase error events"].
+- Invalid example: subject "Finish scope 4 cleanup"; bullets ["Summarize per-scope plan work", "Describe reviewer process"].
+
+Coder whole-plan completion summary:
+{
+  "planGoalSatisfied": false,
+  "whatChangedOverall": "Canonical render matrix pinned across prompt specs.",
+  "verificationSummary": "pnpm typecheck",
+  "remainingKnownGaps": [
+    "One documentation pass remains."
+  ]
+}
+
+Whole-plan completion packet:
+{
+  "executionShape": "multi_scope",
+  "currentScopeLabel": "6",
+  "acceptedScopeRecordCount": 5,
+  "blockedScopeCount": 0,
+  "scopeAccountingSummary": "5 accepted top-level records",
+  "verificationOnlyCompletion": false,
+  "aggregateReviewContext": {
+    "baseCommit": "base000",
+    "headCommit": "head000",
+    "range": "base000..head000",
+    "commitSubjects": [
+      "head000 canonical render matrix"
+    ],
+    "diffStat": " src/example.ts | 2 +-",
+    "changedFiles": [
+      "src/example.ts"
+    ],
+    "unavailableReason": null
+  },
+  "finalCommit": "head000",
+  "completedScopeSummary": "1 accepted; 2 accepted",
+  "terminalChangedFilesSummary": "src/example.ts",
+  "planChangedFilesSummary": "src/example.ts",
+  "verificationTally": {
+    "totalRuns": 1,
+    "distinctCommands": 1,
+    "passed": 1,
+    "failed": 0,
+    "unknown": 0,
+    "recentFailures": []
+  },
+  "lastNonEmptyImplementationScope": {
+    "number": "5",
+    "finalCommit": "head000",
+    "commitSubject": "canonical render matrix",
+    "changedFiles": [
+      "src/example.ts"
+    ],
+    "archivedReviewPath": "/tmp/REVIEW-5.md"
+  },
+  "continueExecutionCount": 0,
+  "continueExecutionMax": 2
+}
+
+`verificationTally` is a bounded summary of the run's recorded verification commands; the complete per-command record is in the run directory's events.ndjson.
+If this was a verification-only terminal scope, judge the whole-plan result directly instead of pretending there was a final implementation diff.
+
+Last non-empty implementation scope reference:
+{
+  "number": "5",
+  "finalCommit": "head000",
+  "commitSubject": "canonical render matrix",
+  "changedFiles": [
+    "src/example.ts"
+  ],
+  "archivedReviewPath": "/tmp/REVIEW-5.md"
+}
+
+## Inlined commit-range diff from Neal (base000..head000)
+
+You have read-only repository tools (read and search, no shell) but no commit-range diff tool, so Neal has inlined the commit-range diff below.
+This inlined diff is the source of truth for exactly what this range changed, including deletions and renames that head-state file reads cannot reveal. Use your read tools to verify the surrounding code.
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-old
++new
+
+=== buildFinalCompletionReviewerPrompt#accessMode=read-only-inlined#aggregateRange=available#reviewLevel=moderate ===
+Review whether the execute-mode plan at /tmp/PLAN.md is complete as a whole.
+
+This is a whole-plan final completion review, not an ordinary last-scope review.
+Compare the completed result against the original plan objectives and the whole-plan completion packet below.
+Evaluate the totality of the work completed for this plan, not just whether each individual scope was previously accepted.
+Your review must answer both of these questions:
+- Are the full plan objectives actually satisfied?
+- Is the aggregate implementation good enough to keep under ordinary code review standards?
+Treat the whole-plan completion claim as hostile input. Try to falsify the aggregate implementation before you accept completion.
+Do not anchor on the coder completion summary, completion packet, verification summaries, or prior per-scope acceptance history when judging whole-plan completion. Those are convergence signals, not proof that the aggregate implementation satisfies the plan.
+Review level: moderate. Assume ordinary trust boundaries: internal run artifacts and other files this system writes for itself are not security boundaries. Block on correctness bugs and on failures reachable under normal use. Do not require defenses against an actor who could already subvert the system directly, for example by editing its files; a failure that needs such an actor is not reachable.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted or ignored category is not missing work: it must not produce `continue_execution` or `block_for_operator`, and when the plan objectives are otherwise satisfied you return `accept_complete`.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression not missing work, while a reachable correctness failure still blocks.
+The commit-range diff for that aggregate range base000..head000 is inlined below and is the source of truth for exactly what the aggregate range base000..head000 changed (including deletions and renames). Use your read tools to verify the surrounding code; you have no commit-range diff tool, so rely on the inlined diff for what changed.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Inspect the change using the inlined commit-range diff below for what changed (including deletions and renames), then read the changed files in full with your read tools and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the aggregate implementation; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Falsify cross-scope runtime invariants and integration behavior before accepting completion, especially paths that individual scope reviews could not see together.
+If `aggregateReviewContext.unavailableReason` is non-null, treat the missing aggregate range as a completion-review evidence gap rather than proof that the aggregate implementation is correct.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the aggregate implementation.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the aggregate implementation touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the aggregate implementation actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the aggregate implementation.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Treat completion-blocking issues like review findings: each one needs concrete evidence, affected files or runtime behavior, and a required correction.
+Use `continue_execution` only for concrete missing work that is bounded enough for one follow-on scope; use `block_for_operator` for ambiguous or externally constrained gaps.
+A finding category that the review level or the User Guidance section has demoted or ignored is not missing work: never return `continue_execution` or `block_for_operator` for it. When the plan objectives are otherwise satisfied, return `accept_complete`.
+Do not turn low-signal style preferences, trivial code-shape preferences, or optional refactors into missing work.
+If the plan is complete aside from low-signal trivia, return `accept_complete` rather than inventing a non-blocking completion concern.
+Review the whole-plan result for correctness and completeness against the plan objectives, regressions or missing behavior, cross-scope integration issues that may not have been visible in individual scope reviews, code quality, maintainability, and consistency of the final implementation, and adequacy of test coverage and verification for the total change.
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+Do not treat prior per-scope acceptance as sufficient evidence that the whole plan is complete or that the aggregate code quality is acceptable.
+Return only JSON that matches the required schema.
+Return the final answer only as the required structured output object, not as prose or markdown.
+Defer exact output framing to the active structured-output transport; do not add your own output-format constraints.
+Use `accept_complete` only when the full plan objectives are satisfied and the aggregate implementation is acceptable under ordinary code review standards.
+Use `continue_execution` only when the remaining work is concrete, bounded, and suitable for one explicit follow-on scope.
+Use `block_for_operator` when the remaining gap is ambiguous, externally constrained, or needs human direction.
+When you return `continue_execution`, you must provide a non-null `missingWork` object with `summary`, `requiredOutcome`, and `verification`.
+When you return any other action, `missingWork` must be null.
+
+Squash commit message rules:
+- `squashCommitMessage` is project-facing Git history for human readers.
+- Use `squashCommitMessage` only for `accept_complete`; when you return any non-accept action, set `squashCommitMessage` to null.
+- For `accept_complete`, provide a non-null object with one concise project-facing `subject` and 2 to 5 high-level `bullets`.
+- Do not mention plan paths, markdown plan filenames, temporary run paths, scope-numbered or per-scope wording, final cleanup, Neal mechanics, provider process, or reviewer process.
+- Summarize the code or product behavior change, not the plan document.
+- Valid example: subject "Persist final completion review failures"; bullets ["Mark invalid verdicts failed", "Record phase error events"].
+- Invalid example: subject "Finish scope 4 cleanup"; bullets ["Summarize per-scope plan work", "Describe reviewer process"].
+
+Coder whole-plan completion summary:
+{
+  "planGoalSatisfied": false,
+  "whatChangedOverall": "Canonical render matrix pinned across prompt specs.",
+  "verificationSummary": "pnpm typecheck",
+  "remainingKnownGaps": [
+    "One documentation pass remains."
+  ]
+}
+
+Whole-plan completion packet:
+{
+  "executionShape": "multi_scope",
+  "currentScopeLabel": "6",
+  "acceptedScopeRecordCount": 5,
+  "blockedScopeCount": 0,
+  "scopeAccountingSummary": "5 accepted top-level records",
+  "verificationOnlyCompletion": false,
+  "aggregateReviewContext": {
+    "baseCommit": "base000",
+    "headCommit": "head000",
+    "range": "base000..head000",
+    "commitSubjects": [
+      "head000 canonical render matrix"
+    ],
+    "diffStat": " src/example.ts | 2 +-",
+    "changedFiles": [
+      "src/example.ts"
+    ],
+    "unavailableReason": null
+  },
+  "finalCommit": "head000",
+  "completedScopeSummary": "1 accepted; 2 accepted",
+  "terminalChangedFilesSummary": "src/example.ts",
+  "planChangedFilesSummary": "src/example.ts",
+  "verificationTally": {
+    "totalRuns": 1,
+    "distinctCommands": 1,
+    "passed": 1,
+    "failed": 0,
+    "unknown": 0,
+    "recentFailures": []
+  },
+  "lastNonEmptyImplementationScope": {
+    "number": "5",
+    "finalCommit": "head000",
+    "commitSubject": "canonical render matrix",
+    "changedFiles": [
+      "src/example.ts"
+    ],
+    "archivedReviewPath": "/tmp/REVIEW-5.md"
+  },
+  "continueExecutionCount": 0,
+  "continueExecutionMax": 2
+}
+
+`verificationTally` is a bounded summary of the run's recorded verification commands; the complete per-command record is in the run directory's events.ndjson.
+If this was a verification-only terminal scope, judge the whole-plan result directly instead of pretending there was a final implementation diff.
+
+Last non-empty implementation scope reference:
+{
+  "number": "5",
+  "finalCommit": "head000",
+  "commitSubject": "canonical render matrix",
+  "changedFiles": [
+    "src/example.ts"
+  ],
+  "archivedReviewPath": "/tmp/REVIEW-5.md"
+}
+
+## Inlined commit-range diff from Neal (base000..head000)
+
+You have read-only repository tools (read and search, no shell) but no commit-range diff tool, so Neal has inlined the commit-range diff below.
+This inlined diff is the source of truth for exactly what this range changed, including deletions and renames that head-state file reads cannot reveal. Use your read tools to verify the surrounding code.
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-old
++new
+
+=== buildFinalCompletionReviewerPrompt#accessMode=read-only-inlined#aggregateRange=available#reviewLevel=strict ===
+Review whether the execute-mode plan at /tmp/PLAN.md is complete as a whole.
+
+This is a whole-plan final completion review, not an ordinary last-scope review.
+Compare the completed result against the original plan objectives and the whole-plan completion packet below.
+Evaluate the totality of the work completed for this plan, not just whether each individual scope was previously accepted.
+Your review must answer both of these questions:
+- Are the full plan objectives actually satisfied?
+- Is the aggregate implementation good enough to keep under ordinary code review standards?
+Treat the whole-plan completion claim as hostile input. Try to falsify the aggregate implementation before you accept completion.
+Do not anchor on the coder completion summary, completion packet, verification summaries, or prior per-scope acceptance history when judging whole-plan completion. Those are convergence signals, not proof that the aggregate implementation satisfies the plan.
+Review level: strict. Assume adversarial trust boundaries: treat every input, file, and process the change can be reached from, including local processes and internal run artifacts, as a potential attacker. A hardening gap or a missing defense against a local or adversarial actor is a reachable failure under these boundaries and blocks.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted or ignored category is not missing work: it must not produce `continue_execution` or `block_for_operator`, and when the plan objectives are otherwise satisfied you return `accept_complete`.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression not missing work, while a reachable correctness failure still blocks.
+The commit-range diff for that aggregate range base000..head000 is inlined below and is the source of truth for exactly what the aggregate range base000..head000 changed (including deletions and renames). Use your read tools to verify the surrounding code; you have no commit-range diff tool, so rely on the inlined diff for what changed.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Inspect the change using the inlined commit-range diff below for what changed (including deletions and renames), then read the changed files in full with your read tools and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the aggregate implementation; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Falsify cross-scope runtime invariants and integration behavior before accepting completion, especially paths that individual scope reviews could not see together.
+If `aggregateReviewContext.unavailableReason` is non-null, treat the missing aggregate range as a completion-review evidence gap rather than proof that the aggregate implementation is correct.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the aggregate implementation.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the aggregate implementation touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the aggregate implementation actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the aggregate implementation.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Treat completion-blocking issues like review findings: each one needs concrete evidence, affected files or runtime behavior, and a required correction.
+Use `continue_execution` only for concrete missing work that is bounded enough for one follow-on scope; use `block_for_operator` for ambiguous or externally constrained gaps.
+A finding category that the review level or the User Guidance section has demoted or ignored is not missing work: never return `continue_execution` or `block_for_operator` for it. When the plan objectives are otherwise satisfied, return `accept_complete`.
+Do not turn low-signal style preferences, trivial code-shape preferences, or optional refactors into missing work.
+If the plan is complete aside from low-signal trivia, return `accept_complete` rather than inventing a non-blocking completion concern.
+Review the whole-plan result for correctness and completeness against the plan objectives, regressions or missing behavior, cross-scope integration issues that may not have been visible in individual scope reviews, code quality, maintainability, and consistency of the final implementation, and adequacy of test coverage and verification for the total change.
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+Do not treat prior per-scope acceptance as sufficient evidence that the whole plan is complete or that the aggregate code quality is acceptable.
+Return only JSON that matches the required schema.
+Return the final answer only as the required structured output object, not as prose or markdown.
+Defer exact output framing to the active structured-output transport; do not add your own output-format constraints.
+Use `accept_complete` only when the full plan objectives are satisfied and the aggregate implementation is acceptable under ordinary code review standards.
+Use `continue_execution` only when the remaining work is concrete, bounded, and suitable for one explicit follow-on scope.
+Use `block_for_operator` when the remaining gap is ambiguous, externally constrained, or needs human direction.
+When you return `continue_execution`, you must provide a non-null `missingWork` object with `summary`, `requiredOutcome`, and `verification`.
+When you return any other action, `missingWork` must be null.
+
+Squash commit message rules:
+- `squashCommitMessage` is project-facing Git history for human readers.
+- Use `squashCommitMessage` only for `accept_complete`; when you return any non-accept action, set `squashCommitMessage` to null.
+- For `accept_complete`, provide a non-null object with one concise project-facing `subject` and 2 to 5 high-level `bullets`.
+- Do not mention plan paths, markdown plan filenames, temporary run paths, scope-numbered or per-scope wording, final cleanup, Neal mechanics, provider process, or reviewer process.
+- Summarize the code or product behavior change, not the plan document.
+- Valid example: subject "Persist final completion review failures"; bullets ["Mark invalid verdicts failed", "Record phase error events"].
+- Invalid example: subject "Finish scope 4 cleanup"; bullets ["Summarize per-scope plan work", "Describe reviewer process"].
+
+Coder whole-plan completion summary:
+{
+  "planGoalSatisfied": false,
+  "whatChangedOverall": "Canonical render matrix pinned across prompt specs.",
+  "verificationSummary": "pnpm typecheck",
+  "remainingKnownGaps": [
+    "One documentation pass remains."
+  ]
+}
+
+Whole-plan completion packet:
+{
+  "executionShape": "multi_scope",
+  "currentScopeLabel": "6",
+  "acceptedScopeRecordCount": 5,
+  "blockedScopeCount": 0,
+  "scopeAccountingSummary": "5 accepted top-level records",
+  "verificationOnlyCompletion": false,
+  "aggregateReviewContext": {
+    "baseCommit": "base000",
+    "headCommit": "head000",
+    "range": "base000..head000",
+    "commitSubjects": [
+      "head000 canonical render matrix"
+    ],
+    "diffStat": " src/example.ts | 2 +-",
+    "changedFiles": [
+      "src/example.ts"
+    ],
+    "unavailableReason": null
+  },
+  "finalCommit": "head000",
+  "completedScopeSummary": "1 accepted; 2 accepted",
+  "terminalChangedFilesSummary": "src/example.ts",
+  "planChangedFilesSummary": "src/example.ts",
+  "verificationTally": {
+    "totalRuns": 1,
+    "distinctCommands": 1,
+    "passed": 1,
+    "failed": 0,
+    "unknown": 0,
+    "recentFailures": []
+  },
+  "lastNonEmptyImplementationScope": {
+    "number": "5",
+    "finalCommit": "head000",
+    "commitSubject": "canonical render matrix",
+    "changedFiles": [
+      "src/example.ts"
+    ],
+    "archivedReviewPath": "/tmp/REVIEW-5.md"
+  },
+  "continueExecutionCount": 0,
+  "continueExecutionMax": 2
+}
+
+`verificationTally` is a bounded summary of the run's recorded verification commands; the complete per-command record is in the run directory's events.ndjson.
+If this was a verification-only terminal scope, judge the whole-plan result directly instead of pretending there was a final implementation diff.
+
+Last non-empty implementation scope reference:
+{
+  "number": "5",
+  "finalCommit": "head000",
+  "commitSubject": "canonical render matrix",
+  "changedFiles": [
+    "src/example.ts"
+  ],
+  "archivedReviewPath": "/tmp/REVIEW-5.md"
+}
+
+## Inlined commit-range diff from Neal (base000..head000)
+
+You have read-only repository tools (read and search, no shell) but no commit-range diff tool, so Neal has inlined the commit-range diff below.
+This inlined diff is the source of truth for exactly what this range changed, including deletions and renames that head-state file reads cannot reveal. Use your read tools to verify the surrounding code.
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-old
++new
+
+=== buildFinalCompletionReviewerPrompt#accessMode=read-only-tool#aggregateRange=available#reviewLevel=lenient ===
+Review whether the execute-mode plan at /tmp/PLAN.md is complete as a whole.
+
+This is a whole-plan final completion review, not an ordinary last-scope review.
+Compare the completed result against the original plan objectives and the whole-plan completion packet below.
+Evaluate the totality of the work completed for this plan, not just whether each individual scope was previously accepted.
+Your review must answer both of these questions:
+- Are the full plan objectives actually satisfied?
+- Is the aggregate implementation good enough to keep under ordinary code review standards?
+Treat the whole-plan completion claim as hostile input. Try to falsify the aggregate implementation before you accept completion.
+Do not anchor on the coder completion summary, completion packet, verification summaries, or prior per-scope acceptance history when judging whole-plan completion. Those are convergence signals, not proof that the aggregate implementation satisfies the plan.
+Review level: lenient. Assume ordinary trust boundaries and block only on correctness failures and real, reachable bugs. Do not demand additional robustness, hardening, performance, or style work as a condition of acceptance.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted or ignored category is not missing work: it must not produce `continue_execution` or `block_for_operator`, and when the plan objectives are otherwise satisfied you return `accept_complete`.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression not missing work, while a reachable correctness failure still blocks.
+Review that aggregate range base000..head000 directly with your read-only repository tools: use the git_diff tool to see exactly what the aggregate range base000..head000 changed (including deletions and renames), and your read tools to verify the surrounding code. The aggregate range base000..head000 is the source of truth for this review.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Inspect the change with your read-only tools: call git_diff with the base and head commits named in this prompt (stat:true first for the changed-file overview, then per-path diffs), read the changed files in full, and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the aggregate implementation; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Falsify cross-scope runtime invariants and integration behavior before accepting completion, especially paths that individual scope reviews could not see together.
+If `aggregateReviewContext.unavailableReason` is non-null, treat the missing aggregate range as a completion-review evidence gap rather than proof that the aggregate implementation is correct.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the aggregate implementation.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the aggregate implementation touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the aggregate implementation actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the aggregate implementation.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Treat completion-blocking issues like review findings: each one needs concrete evidence, affected files or runtime behavior, and a required correction.
+Use `continue_execution` only for concrete missing work that is bounded enough for one follow-on scope; use `block_for_operator` for ambiguous or externally constrained gaps.
+A finding category that the review level or the User Guidance section has demoted or ignored is not missing work: never return `continue_execution` or `block_for_operator` for it. When the plan objectives are otherwise satisfied, return `accept_complete`.
+Do not turn low-signal style preferences, trivial code-shape preferences, or optional refactors into missing work.
+If the plan is complete aside from low-signal trivia, return `accept_complete` rather than inventing a non-blocking completion concern.
+Review the whole-plan result for correctness and completeness against the plan objectives, regressions or missing behavior, cross-scope integration issues that may not have been visible in individual scope reviews, code quality, maintainability, and consistency of the final implementation, and adequacy of test coverage and verification for the total change.
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+Do not treat prior per-scope acceptance as sufficient evidence that the whole plan is complete or that the aggregate code quality is acceptable.
+Return only JSON that matches the required schema.
+Return the final answer only as the required structured output object, not as prose or markdown.
+Defer exact output framing to the active structured-output transport; do not add your own output-format constraints.
+Use `accept_complete` only when the full plan objectives are satisfied and the aggregate implementation is acceptable under ordinary code review standards.
+Use `continue_execution` only when the remaining work is concrete, bounded, and suitable for one explicit follow-on scope.
+Use `block_for_operator` when the remaining gap is ambiguous, externally constrained, or needs human direction.
+When you return `continue_execution`, you must provide a non-null `missingWork` object with `summary`, `requiredOutcome`, and `verification`.
+When you return any other action, `missingWork` must be null.
+
+Squash commit message rules:
+- `squashCommitMessage` is project-facing Git history for human readers.
+- Use `squashCommitMessage` only for `accept_complete`; when you return any non-accept action, set `squashCommitMessage` to null.
+- For `accept_complete`, provide a non-null object with one concise project-facing `subject` and 2 to 5 high-level `bullets`.
+- Do not mention plan paths, markdown plan filenames, temporary run paths, scope-numbered or per-scope wording, final cleanup, Neal mechanics, provider process, or reviewer process.
+- Summarize the code or product behavior change, not the plan document.
+- Valid example: subject "Persist final completion review failures"; bullets ["Mark invalid verdicts failed", "Record phase error events"].
+- Invalid example: subject "Finish scope 4 cleanup"; bullets ["Summarize per-scope plan work", "Describe reviewer process"].
+
+Coder whole-plan completion summary:
+{
+  "planGoalSatisfied": false,
+  "whatChangedOverall": "Canonical render matrix pinned across prompt specs.",
+  "verificationSummary": "pnpm typecheck",
+  "remainingKnownGaps": [
+    "One documentation pass remains."
+  ]
+}
+
+Whole-plan completion packet:
+{
+  "executionShape": "multi_scope",
+  "currentScopeLabel": "6",
+  "acceptedScopeRecordCount": 5,
+  "blockedScopeCount": 0,
+  "scopeAccountingSummary": "5 accepted top-level records",
+  "verificationOnlyCompletion": false,
+  "aggregateReviewContext": {
+    "baseCommit": "base000",
+    "headCommit": "head000",
+    "range": "base000..head000",
+    "commitSubjects": [
+      "head000 canonical render matrix"
+    ],
+    "diffStat": " src/example.ts | 2 +-",
+    "changedFiles": [
+      "src/example.ts"
+    ],
+    "unavailableReason": null
+  },
+  "finalCommit": "head000",
+  "completedScopeSummary": "1 accepted; 2 accepted",
+  "terminalChangedFilesSummary": "src/example.ts",
+  "planChangedFilesSummary": "src/example.ts",
+  "verificationTally": {
+    "totalRuns": 1,
+    "distinctCommands": 1,
+    "passed": 1,
+    "failed": 0,
+    "unknown": 0,
+    "recentFailures": []
+  },
+  "lastNonEmptyImplementationScope": {
+    "number": "5",
+    "finalCommit": "head000",
+    "commitSubject": "canonical render matrix",
+    "changedFiles": [
+      "src/example.ts"
+    ],
+    "archivedReviewPath": "/tmp/REVIEW-5.md"
+  },
+  "continueExecutionCount": 0,
+  "continueExecutionMax": 2
+}
+
+`verificationTally` is a bounded summary of the run's recorded verification commands; the complete per-command record is in the run directory's events.ndjson.
+If this was a verification-only terminal scope, judge the whole-plan result directly instead of pretending there was a final implementation diff.
+
+Last non-empty implementation scope reference:
+{
+  "number": "5",
+  "finalCommit": "head000",
+  "commitSubject": "canonical render matrix",
+  "changedFiles": [
+    "src/example.ts"
+  ],
+  "archivedReviewPath": "/tmp/REVIEW-5.md"
+}
+=== buildFinalCompletionReviewerPrompt#accessMode=read-only-tool#aggregateRange=available#reviewLevel=moderate ===
+Review whether the execute-mode plan at /tmp/PLAN.md is complete as a whole.
+
+This is a whole-plan final completion review, not an ordinary last-scope review.
+Compare the completed result against the original plan objectives and the whole-plan completion packet below.
+Evaluate the totality of the work completed for this plan, not just whether each individual scope was previously accepted.
+Your review must answer both of these questions:
+- Are the full plan objectives actually satisfied?
+- Is the aggregate implementation good enough to keep under ordinary code review standards?
+Treat the whole-plan completion claim as hostile input. Try to falsify the aggregate implementation before you accept completion.
+Do not anchor on the coder completion summary, completion packet, verification summaries, or prior per-scope acceptance history when judging whole-plan completion. Those are convergence signals, not proof that the aggregate implementation satisfies the plan.
+Review level: moderate. Assume ordinary trust boundaries: internal run artifacts and other files this system writes for itself are not security boundaries. Block on correctness bugs and on failures reachable under normal use. Do not require defenses against an actor who could already subvert the system directly, for example by editing its files; a failure that needs such an actor is not reachable.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted or ignored category is not missing work: it must not produce `continue_execution` or `block_for_operator`, and when the plan objectives are otherwise satisfied you return `accept_complete`.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression not missing work, while a reachable correctness failure still blocks.
+Review that aggregate range base000..head000 directly with your read-only repository tools: use the git_diff tool to see exactly what the aggregate range base000..head000 changed (including deletions and renames), and your read tools to verify the surrounding code. The aggregate range base000..head000 is the source of truth for this review.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Inspect the change with your read-only tools: call git_diff with the base and head commits named in this prompt (stat:true first for the changed-file overview, then per-path diffs), read the changed files in full, and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the aggregate implementation; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Falsify cross-scope runtime invariants and integration behavior before accepting completion, especially paths that individual scope reviews could not see together.
+If `aggregateReviewContext.unavailableReason` is non-null, treat the missing aggregate range as a completion-review evidence gap rather than proof that the aggregate implementation is correct.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the aggregate implementation.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the aggregate implementation touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the aggregate implementation actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the aggregate implementation.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Treat completion-blocking issues like review findings: each one needs concrete evidence, affected files or runtime behavior, and a required correction.
+Use `continue_execution` only for concrete missing work that is bounded enough for one follow-on scope; use `block_for_operator` for ambiguous or externally constrained gaps.
+A finding category that the review level or the User Guidance section has demoted or ignored is not missing work: never return `continue_execution` or `block_for_operator` for it. When the plan objectives are otherwise satisfied, return `accept_complete`.
+Do not turn low-signal style preferences, trivial code-shape preferences, or optional refactors into missing work.
+If the plan is complete aside from low-signal trivia, return `accept_complete` rather than inventing a non-blocking completion concern.
+Review the whole-plan result for correctness and completeness against the plan objectives, regressions or missing behavior, cross-scope integration issues that may not have been visible in individual scope reviews, code quality, maintainability, and consistency of the final implementation, and adequacy of test coverage and verification for the total change.
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+Do not treat prior per-scope acceptance as sufficient evidence that the whole plan is complete or that the aggregate code quality is acceptable.
+Return only JSON that matches the required schema.
+Return the final answer only as the required structured output object, not as prose or markdown.
+Defer exact output framing to the active structured-output transport; do not add your own output-format constraints.
+Use `accept_complete` only when the full plan objectives are satisfied and the aggregate implementation is acceptable under ordinary code review standards.
+Use `continue_execution` only when the remaining work is concrete, bounded, and suitable for one explicit follow-on scope.
+Use `block_for_operator` when the remaining gap is ambiguous, externally constrained, or needs human direction.
+When you return `continue_execution`, you must provide a non-null `missingWork` object with `summary`, `requiredOutcome`, and `verification`.
+When you return any other action, `missingWork` must be null.
+
+Squash commit message rules:
+- `squashCommitMessage` is project-facing Git history for human readers.
+- Use `squashCommitMessage` only for `accept_complete`; when you return any non-accept action, set `squashCommitMessage` to null.
+- For `accept_complete`, provide a non-null object with one concise project-facing `subject` and 2 to 5 high-level `bullets`.
+- Do not mention plan paths, markdown plan filenames, temporary run paths, scope-numbered or per-scope wording, final cleanup, Neal mechanics, provider process, or reviewer process.
+- Summarize the code or product behavior change, not the plan document.
+- Valid example: subject "Persist final completion review failures"; bullets ["Mark invalid verdicts failed", "Record phase error events"].
+- Invalid example: subject "Finish scope 4 cleanup"; bullets ["Summarize per-scope plan work", "Describe reviewer process"].
+
+Coder whole-plan completion summary:
+{
+  "planGoalSatisfied": false,
+  "whatChangedOverall": "Canonical render matrix pinned across prompt specs.",
+  "verificationSummary": "pnpm typecheck",
+  "remainingKnownGaps": [
+    "One documentation pass remains."
+  ]
+}
+
+Whole-plan completion packet:
+{
+  "executionShape": "multi_scope",
+  "currentScopeLabel": "6",
+  "acceptedScopeRecordCount": 5,
+  "blockedScopeCount": 0,
+  "scopeAccountingSummary": "5 accepted top-level records",
+  "verificationOnlyCompletion": false,
+  "aggregateReviewContext": {
+    "baseCommit": "base000",
+    "headCommit": "head000",
+    "range": "base000..head000",
+    "commitSubjects": [
+      "head000 canonical render matrix"
+    ],
+    "diffStat": " src/example.ts | 2 +-",
+    "changedFiles": [
+      "src/example.ts"
+    ],
+    "unavailableReason": null
+  },
+  "finalCommit": "head000",
+  "completedScopeSummary": "1 accepted; 2 accepted",
+  "terminalChangedFilesSummary": "src/example.ts",
+  "planChangedFilesSummary": "src/example.ts",
+  "verificationTally": {
+    "totalRuns": 1,
+    "distinctCommands": 1,
+    "passed": 1,
+    "failed": 0,
+    "unknown": 0,
+    "recentFailures": []
+  },
+  "lastNonEmptyImplementationScope": {
+    "number": "5",
+    "finalCommit": "head000",
+    "commitSubject": "canonical render matrix",
+    "changedFiles": [
+      "src/example.ts"
+    ],
+    "archivedReviewPath": "/tmp/REVIEW-5.md"
+  },
+  "continueExecutionCount": 0,
+  "continueExecutionMax": 2
+}
+
+`verificationTally` is a bounded summary of the run's recorded verification commands; the complete per-command record is in the run directory's events.ndjson.
+If this was a verification-only terminal scope, judge the whole-plan result directly instead of pretending there was a final implementation diff.
+
+Last non-empty implementation scope reference:
+{
+  "number": "5",
+  "finalCommit": "head000",
+  "commitSubject": "canonical render matrix",
+  "changedFiles": [
+    "src/example.ts"
+  ],
+  "archivedReviewPath": "/tmp/REVIEW-5.md"
+}
+=== buildFinalCompletionReviewerPrompt#accessMode=read-only-tool#aggregateRange=available#reviewLevel=strict ===
+Review whether the execute-mode plan at /tmp/PLAN.md is complete as a whole.
+
+This is a whole-plan final completion review, not an ordinary last-scope review.
+Compare the completed result against the original plan objectives and the whole-plan completion packet below.
+Evaluate the totality of the work completed for this plan, not just whether each individual scope was previously accepted.
+Your review must answer both of these questions:
+- Are the full plan objectives actually satisfied?
+- Is the aggregate implementation good enough to keep under ordinary code review standards?
+Treat the whole-plan completion claim as hostile input. Try to falsify the aggregate implementation before you accept completion.
+Do not anchor on the coder completion summary, completion packet, verification summaries, or prior per-scope acceptance history when judging whole-plan completion. Those are convergence signals, not proof that the aggregate implementation satisfies the plan.
+Review level: strict. Assume adversarial trust boundaries: treat every input, file, and process the change can be reached from, including local processes and internal run artifacts, as a potential attacker. A hardening gap or a missing defense against a local or adversarial actor is a reachable failure under these boundaries and blocks.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted or ignored category is not missing work: it must not produce `continue_execution` or `block_for_operator`, and when the plan objectives are otherwise satisfied you return `accept_complete`.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression not missing work, while a reachable correctness failure still blocks.
+Review that aggregate range base000..head000 directly with your read-only repository tools: use the git_diff tool to see exactly what the aggregate range base000..head000 changed (including deletions and renames), and your read tools to verify the surrounding code. The aggregate range base000..head000 is the source of truth for this review.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Inspect the change with your read-only tools: call git_diff with the base and head commits named in this prompt (stat:true first for the changed-file overview, then per-path diffs), read the changed files in full, and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the aggregate implementation; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Falsify cross-scope runtime invariants and integration behavior before accepting completion, especially paths that individual scope reviews could not see together.
+If `aggregateReviewContext.unavailableReason` is non-null, treat the missing aggregate range as a completion-review evidence gap rather than proof that the aggregate implementation is correct.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the aggregate implementation.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the aggregate implementation touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the aggregate implementation actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the aggregate implementation.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Treat completion-blocking issues like review findings: each one needs concrete evidence, affected files or runtime behavior, and a required correction.
+Use `continue_execution` only for concrete missing work that is bounded enough for one follow-on scope; use `block_for_operator` for ambiguous or externally constrained gaps.
+A finding category that the review level or the User Guidance section has demoted or ignored is not missing work: never return `continue_execution` or `block_for_operator` for it. When the plan objectives are otherwise satisfied, return `accept_complete`.
+Do not turn low-signal style preferences, trivial code-shape preferences, or optional refactors into missing work.
+If the plan is complete aside from low-signal trivia, return `accept_complete` rather than inventing a non-blocking completion concern.
+Review the whole-plan result for correctness and completeness against the plan objectives, regressions or missing behavior, cross-scope integration issues that may not have been visible in individual scope reviews, code quality, maintainability, and consistency of the final implementation, and adequacy of test coverage and verification for the total change.
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+Do not treat prior per-scope acceptance as sufficient evidence that the whole plan is complete or that the aggregate code quality is acceptable.
+Return only JSON that matches the required schema.
+Return the final answer only as the required structured output object, not as prose or markdown.
+Defer exact output framing to the active structured-output transport; do not add your own output-format constraints.
+Use `accept_complete` only when the full plan objectives are satisfied and the aggregate implementation is acceptable under ordinary code review standards.
+Use `continue_execution` only when the remaining work is concrete, bounded, and suitable for one explicit follow-on scope.
+Use `block_for_operator` when the remaining gap is ambiguous, externally constrained, or needs human direction.
+When you return `continue_execution`, you must provide a non-null `missingWork` object with `summary`, `requiredOutcome`, and `verification`.
+When you return any other action, `missingWork` must be null.
+
+Squash commit message rules:
+- `squashCommitMessage` is project-facing Git history for human readers.
+- Use `squashCommitMessage` only for `accept_complete`; when you return any non-accept action, set `squashCommitMessage` to null.
+- For `accept_complete`, provide a non-null object with one concise project-facing `subject` and 2 to 5 high-level `bullets`.
+- Do not mention plan paths, markdown plan filenames, temporary run paths, scope-numbered or per-scope wording, final cleanup, Neal mechanics, provider process, or reviewer process.
+- Summarize the code or product behavior change, not the plan document.
+- Valid example: subject "Persist final completion review failures"; bullets ["Mark invalid verdicts failed", "Record phase error events"].
+- Invalid example: subject "Finish scope 4 cleanup"; bullets ["Summarize per-scope plan work", "Describe reviewer process"].
+
+Coder whole-plan completion summary:
+{
+  "planGoalSatisfied": false,
+  "whatChangedOverall": "Canonical render matrix pinned across prompt specs.",
+  "verificationSummary": "pnpm typecheck",
+  "remainingKnownGaps": [
+    "One documentation pass remains."
+  ]
+}
+
+Whole-plan completion packet:
+{
+  "executionShape": "multi_scope",
+  "currentScopeLabel": "6",
+  "acceptedScopeRecordCount": 5,
+  "blockedScopeCount": 0,
+  "scopeAccountingSummary": "5 accepted top-level records",
+  "verificationOnlyCompletion": false,
+  "aggregateReviewContext": {
+    "baseCommit": "base000",
+    "headCommit": "head000",
+    "range": "base000..head000",
+    "commitSubjects": [
+      "head000 canonical render matrix"
+    ],
+    "diffStat": " src/example.ts | 2 +-",
+    "changedFiles": [
+      "src/example.ts"
+    ],
+    "unavailableReason": null
+  },
+  "finalCommit": "head000",
+  "completedScopeSummary": "1 accepted; 2 accepted",
+  "terminalChangedFilesSummary": "src/example.ts",
+  "planChangedFilesSummary": "src/example.ts",
+  "verificationTally": {
+    "totalRuns": 1,
+    "distinctCommands": 1,
+    "passed": 1,
+    "failed": 0,
+    "unknown": 0,
+    "recentFailures": []
+  },
+  "lastNonEmptyImplementationScope": {
+    "number": "5",
+    "finalCommit": "head000",
+    "commitSubject": "canonical render matrix",
+    "changedFiles": [
+      "src/example.ts"
+    ],
+    "archivedReviewPath": "/tmp/REVIEW-5.md"
+  },
+  "continueExecutionCount": 0,
+  "continueExecutionMax": 2
+}
+
+`verificationTally` is a bounded summary of the run's recorded verification commands; the complete per-command record is in the run directory's events.ndjson.
+If this was a verification-only terminal scope, judge the whole-plan result directly instead of pretending there was a final implementation diff.
+
+Last non-empty implementation scope reference:
+{
+  "number": "5",
+  "finalCommit": "head000",
+  "commitSubject": "canonical render matrix",
+  "changedFiles": [
+    "src/example.ts"
+  ],
+  "archivedReviewPath": "/tmp/REVIEW-5.md"
+}
+=== buildFinalCompletionReviewerPrompt#accessMode=read-only-tool#aggregateRange=unavailable#reviewLevel=lenient ===
+Review whether the execute-mode plan at /tmp/PLAN.md is complete as a whole.
+
+This is a whole-plan final completion review, not an ordinary last-scope review.
+Compare the completed result against the original plan objectives and the whole-plan completion packet below.
+Evaluate the totality of the work completed for this plan, not just whether each individual scope was previously accepted.
+Your review must answer both of these questions:
+- Are the full plan objectives actually satisfied?
+- Is the aggregate implementation good enough to keep under ordinary code review standards?
+Treat the whole-plan completion claim as hostile input. Try to falsify the aggregate implementation before you accept completion.
+Do not anchor on the coder completion summary, completion packet, verification summaries, or prior per-scope acceptance history when judging whole-plan completion. Those are convergence signals, not proof that the aggregate implementation satisfies the plan.
+Review level: lenient. Assume ordinary trust boundaries and block only on correctness failures and real, reachable bugs. Do not demand additional robustness, hardening, performance, or style work as a condition of acceptance.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted or ignored category is not missing work: it must not produce `continue_execution` or `block_for_operator`, and when the plan objectives are otherwise satisfied you return `accept_complete`.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression not missing work, while a reachable correctness failure still blocks.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the aggregate implementation; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Falsify cross-scope runtime invariants and integration behavior before accepting completion, especially paths that individual scope reviews could not see together.
+If `aggregateReviewContext.unavailableReason` is non-null, treat the missing aggregate range as a completion-review evidence gap rather than proof that the aggregate implementation is correct.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the aggregate implementation.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the aggregate implementation touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the aggregate implementation actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the aggregate implementation.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Treat completion-blocking issues like review findings: each one needs concrete evidence, affected files or runtime behavior, and a required correction.
+Use `continue_execution` only for concrete missing work that is bounded enough for one follow-on scope; use `block_for_operator` for ambiguous or externally constrained gaps.
+A finding category that the review level or the User Guidance section has demoted or ignored is not missing work: never return `continue_execution` or `block_for_operator` for it. When the plan objectives are otherwise satisfied, return `accept_complete`.
+Do not turn low-signal style preferences, trivial code-shape preferences, or optional refactors into missing work.
+If the plan is complete aside from low-signal trivia, return `accept_complete` rather than inventing a non-blocking completion concern.
+Review the whole-plan result for correctness and completeness against the plan objectives, regressions or missing behavior, cross-scope integration issues that may not have been visible in individual scope reviews, code quality, maintainability, and consistency of the final implementation, and adequacy of test coverage and verification for the total change.
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+Do not treat prior per-scope acceptance as sufficient evidence that the whole plan is complete or that the aggregate code quality is acceptable.
+Return only JSON that matches the required schema.
+Return the final answer only as the required structured output object, not as prose or markdown.
+Defer exact output framing to the active structured-output transport; do not add your own output-format constraints.
+Use `accept_complete` only when the full plan objectives are satisfied and the aggregate implementation is acceptable under ordinary code review standards.
+Use `continue_execution` only when the remaining work is concrete, bounded, and suitable for one explicit follow-on scope.
+Use `block_for_operator` when the remaining gap is ambiguous, externally constrained, or needs human direction.
+When you return `continue_execution`, you must provide a non-null `missingWork` object with `summary`, `requiredOutcome`, and `verification`.
+When you return any other action, `missingWork` must be null.
+
+Squash commit message rules:
+- `squashCommitMessage` is project-facing Git history for human readers.
+- Use `squashCommitMessage` only for `accept_complete`; when you return any non-accept action, set `squashCommitMessage` to null.
+- For `accept_complete`, provide a non-null object with one concise project-facing `subject` and 2 to 5 high-level `bullets`.
+- Do not mention plan paths, markdown plan filenames, temporary run paths, scope-numbered or per-scope wording, final cleanup, Neal mechanics, provider process, or reviewer process.
+- Summarize the code or product behavior change, not the plan document.
+- Valid example: subject "Persist final completion review failures"; bullets ["Mark invalid verdicts failed", "Record phase error events"].
+- Invalid example: subject "Finish scope 4 cleanup"; bullets ["Summarize per-scope plan work", "Describe reviewer process"].
+
+Coder whole-plan completion summary:
+{
+  "planGoalSatisfied": false,
+  "whatChangedOverall": "Canonical render matrix pinned across prompt specs.",
+  "verificationSummary": "pnpm typecheck",
+  "remainingKnownGaps": [
+    "One documentation pass remains."
+  ]
+}
+
+Whole-plan completion packet:
+{
+  "executionShape": "multi_scope",
+  "currentScopeLabel": "6",
+  "acceptedScopeRecordCount": 5,
+  "blockedScopeCount": 0,
+  "scopeAccountingSummary": "5 accepted top-level records",
+  "verificationOnlyCompletion": false,
+  "aggregateReviewContext": {
+    "baseCommit": null,
+    "headCommit": null,
+    "range": null,
+    "commitSubjects": [],
+    "diffStat": "",
+    "changedFiles": [],
+    "unavailableReason": "no aggregate commit range was resolved"
+  },
+  "finalCommit": null,
+  "completedScopeSummary": "1 accepted; 2 accepted",
+  "terminalChangedFilesSummary": "src/example.ts",
+  "planChangedFilesSummary": "src/example.ts",
+  "verificationTally": {
+    "totalRuns": 1,
+    "distinctCommands": 1,
+    "passed": 1,
+    "failed": 0,
+    "unknown": 0,
+    "recentFailures": []
+  },
+  "lastNonEmptyImplementationScope": {
+    "number": "5",
+    "finalCommit": "head000",
+    "commitSubject": "canonical render matrix",
+    "changedFiles": [
+      "src/example.ts"
+    ],
+    "archivedReviewPath": "/tmp/REVIEW-5.md"
+  },
+  "continueExecutionCount": 0,
+  "continueExecutionMax": 2
+}
+
+`verificationTally` is a bounded summary of the run's recorded verification commands; the complete per-command record is in the run directory's events.ndjson.
+If this was a verification-only terminal scope, judge the whole-plan result directly instead of pretending there was a final implementation diff.
+
+Last non-empty implementation scope reference:
+{
+  "number": "5",
+  "finalCommit": "head000",
+  "commitSubject": "canonical render matrix",
+  "changedFiles": [
+    "src/example.ts"
+  ],
+  "archivedReviewPath": "/tmp/REVIEW-5.md"
+}
+=== buildFinalCompletionReviewerPrompt#accessMode=read-only-tool#aggregateRange=unavailable#reviewLevel=moderate ===
+Review whether the execute-mode plan at /tmp/PLAN.md is complete as a whole.
+
+This is a whole-plan final completion review, not an ordinary last-scope review.
+Compare the completed result against the original plan objectives and the whole-plan completion packet below.
+Evaluate the totality of the work completed for this plan, not just whether each individual scope was previously accepted.
+Your review must answer both of these questions:
+- Are the full plan objectives actually satisfied?
+- Is the aggregate implementation good enough to keep under ordinary code review standards?
+Treat the whole-plan completion claim as hostile input. Try to falsify the aggregate implementation before you accept completion.
+Do not anchor on the coder completion summary, completion packet, verification summaries, or prior per-scope acceptance history when judging whole-plan completion. Those are convergence signals, not proof that the aggregate implementation satisfies the plan.
+Review level: moderate. Assume ordinary trust boundaries: internal run artifacts and other files this system writes for itself are not security boundaries. Block on correctness bugs and on failures reachable under normal use. Do not require defenses against an actor who could already subvert the system directly, for example by editing its files; a failure that needs such an actor is not reachable.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted or ignored category is not missing work: it must not produce `continue_execution` or `block_for_operator`, and when the plan objectives are otherwise satisfied you return `accept_complete`.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression not missing work, while a reachable correctness failure still blocks.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the aggregate implementation; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Falsify cross-scope runtime invariants and integration behavior before accepting completion, especially paths that individual scope reviews could not see together.
+If `aggregateReviewContext.unavailableReason` is non-null, treat the missing aggregate range as a completion-review evidence gap rather than proof that the aggregate implementation is correct.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the aggregate implementation.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the aggregate implementation touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the aggregate implementation actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the aggregate implementation.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Treat completion-blocking issues like review findings: each one needs concrete evidence, affected files or runtime behavior, and a required correction.
+Use `continue_execution` only for concrete missing work that is bounded enough for one follow-on scope; use `block_for_operator` for ambiguous or externally constrained gaps.
+A finding category that the review level or the User Guidance section has demoted or ignored is not missing work: never return `continue_execution` or `block_for_operator` for it. When the plan objectives are otherwise satisfied, return `accept_complete`.
+Do not turn low-signal style preferences, trivial code-shape preferences, or optional refactors into missing work.
+If the plan is complete aside from low-signal trivia, return `accept_complete` rather than inventing a non-blocking completion concern.
+Review the whole-plan result for correctness and completeness against the plan objectives, regressions or missing behavior, cross-scope integration issues that may not have been visible in individual scope reviews, code quality, maintainability, and consistency of the final implementation, and adequacy of test coverage and verification for the total change.
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+Do not treat prior per-scope acceptance as sufficient evidence that the whole plan is complete or that the aggregate code quality is acceptable.
+Return only JSON that matches the required schema.
+Return the final answer only as the required structured output object, not as prose or markdown.
+Defer exact output framing to the active structured-output transport; do not add your own output-format constraints.
+Use `accept_complete` only when the full plan objectives are satisfied and the aggregate implementation is acceptable under ordinary code review standards.
+Use `continue_execution` only when the remaining work is concrete, bounded, and suitable for one explicit follow-on scope.
+Use `block_for_operator` when the remaining gap is ambiguous, externally constrained, or needs human direction.
+When you return `continue_execution`, you must provide a non-null `missingWork` object with `summary`, `requiredOutcome`, and `verification`.
+When you return any other action, `missingWork` must be null.
+
+Squash commit message rules:
+- `squashCommitMessage` is project-facing Git history for human readers.
+- Use `squashCommitMessage` only for `accept_complete`; when you return any non-accept action, set `squashCommitMessage` to null.
+- For `accept_complete`, provide a non-null object with one concise project-facing `subject` and 2 to 5 high-level `bullets`.
+- Do not mention plan paths, markdown plan filenames, temporary run paths, scope-numbered or per-scope wording, final cleanup, Neal mechanics, provider process, or reviewer process.
+- Summarize the code or product behavior change, not the plan document.
+- Valid example: subject "Persist final completion review failures"; bullets ["Mark invalid verdicts failed", "Record phase error events"].
+- Invalid example: subject "Finish scope 4 cleanup"; bullets ["Summarize per-scope plan work", "Describe reviewer process"].
+
+Coder whole-plan completion summary:
+{
+  "planGoalSatisfied": false,
+  "whatChangedOverall": "Canonical render matrix pinned across prompt specs.",
+  "verificationSummary": "pnpm typecheck",
+  "remainingKnownGaps": [
+    "One documentation pass remains."
+  ]
+}
+
+Whole-plan completion packet:
+{
+  "executionShape": "multi_scope",
+  "currentScopeLabel": "6",
+  "acceptedScopeRecordCount": 5,
+  "blockedScopeCount": 0,
+  "scopeAccountingSummary": "5 accepted top-level records",
+  "verificationOnlyCompletion": false,
+  "aggregateReviewContext": {
+    "baseCommit": null,
+    "headCommit": null,
+    "range": null,
+    "commitSubjects": [],
+    "diffStat": "",
+    "changedFiles": [],
+    "unavailableReason": "no aggregate commit range was resolved"
+  },
+  "finalCommit": null,
+  "completedScopeSummary": "1 accepted; 2 accepted",
+  "terminalChangedFilesSummary": "src/example.ts",
+  "planChangedFilesSummary": "src/example.ts",
+  "verificationTally": {
+    "totalRuns": 1,
+    "distinctCommands": 1,
+    "passed": 1,
+    "failed": 0,
+    "unknown": 0,
+    "recentFailures": []
+  },
+  "lastNonEmptyImplementationScope": {
+    "number": "5",
+    "finalCommit": "head000",
+    "commitSubject": "canonical render matrix",
+    "changedFiles": [
+      "src/example.ts"
+    ],
+    "archivedReviewPath": "/tmp/REVIEW-5.md"
+  },
+  "continueExecutionCount": 0,
+  "continueExecutionMax": 2
+}
+
+`verificationTally` is a bounded summary of the run's recorded verification commands; the complete per-command record is in the run directory's events.ndjson.
+If this was a verification-only terminal scope, judge the whole-plan result directly instead of pretending there was a final implementation diff.
+
+Last non-empty implementation scope reference:
+{
+  "number": "5",
+  "finalCommit": "head000",
+  "commitSubject": "canonical render matrix",
+  "changedFiles": [
+    "src/example.ts"
+  ],
+  "archivedReviewPath": "/tmp/REVIEW-5.md"
+}
+=== buildFinalCompletionReviewerPrompt#accessMode=read-only-tool#aggregateRange=unavailable#reviewLevel=strict ===
+Review whether the execute-mode plan at /tmp/PLAN.md is complete as a whole.
+
+This is a whole-plan final completion review, not an ordinary last-scope review.
+Compare the completed result against the original plan objectives and the whole-plan completion packet below.
+Evaluate the totality of the work completed for this plan, not just whether each individual scope was previously accepted.
+Your review must answer both of these questions:
+- Are the full plan objectives actually satisfied?
+- Is the aggregate implementation good enough to keep under ordinary code review standards?
+Treat the whole-plan completion claim as hostile input. Try to falsify the aggregate implementation before you accept completion.
+Do not anchor on the coder completion summary, completion packet, verification summaries, or prior per-scope acceptance history when judging whole-plan completion. Those are convergence signals, not proof that the aggregate implementation satisfies the plan.
+Review level: strict. Assume adversarial trust boundaries: treat every input, file, and process the change can be reached from, including local processes and internal run artifacts, as a potential attacker. A hardening gap or a missing defense against a local or adversarial actor is a reachable failure under these boundaries and blocks.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted or ignored category is not missing work: it must not produce `continue_execution` or `block_for_operator`, and when the plan objectives are otherwise satisfied you return `accept_complete`.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression not missing work, while a reachable correctness failure still blocks.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the aggregate implementation; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Falsify cross-scope runtime invariants and integration behavior before accepting completion, especially paths that individual scope reviews could not see together.
+If `aggregateReviewContext.unavailableReason` is non-null, treat the missing aggregate range as a completion-review evidence gap rather than proof that the aggregate implementation is correct.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the aggregate implementation.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the aggregate implementation touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the aggregate implementation actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the aggregate implementation.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Treat completion-blocking issues like review findings: each one needs concrete evidence, affected files or runtime behavior, and a required correction.
+Use `continue_execution` only for concrete missing work that is bounded enough for one follow-on scope; use `block_for_operator` for ambiguous or externally constrained gaps.
+A finding category that the review level or the User Guidance section has demoted or ignored is not missing work: never return `continue_execution` or `block_for_operator` for it. When the plan objectives are otherwise satisfied, return `accept_complete`.
+Do not turn low-signal style preferences, trivial code-shape preferences, or optional refactors into missing work.
+If the plan is complete aside from low-signal trivia, return `accept_complete` rather than inventing a non-blocking completion concern.
+Review the whole-plan result for correctness and completeness against the plan objectives, regressions or missing behavior, cross-scope integration issues that may not have been visible in individual scope reviews, code quality, maintainability, and consistency of the final implementation, and adequacy of test coverage and verification for the total change.
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+Do not treat prior per-scope acceptance as sufficient evidence that the whole plan is complete or that the aggregate code quality is acceptable.
+Return only JSON that matches the required schema.
+Return the final answer only as the required structured output object, not as prose or markdown.
+Defer exact output framing to the active structured-output transport; do not add your own output-format constraints.
+Use `accept_complete` only when the full plan objectives are satisfied and the aggregate implementation is acceptable under ordinary code review standards.
+Use `continue_execution` only when the remaining work is concrete, bounded, and suitable for one explicit follow-on scope.
+Use `block_for_operator` when the remaining gap is ambiguous, externally constrained, or needs human direction.
+When you return `continue_execution`, you must provide a non-null `missingWork` object with `summary`, `requiredOutcome`, and `verification`.
+When you return any other action, `missingWork` must be null.
+
+Squash commit message rules:
+- `squashCommitMessage` is project-facing Git history for human readers.
+- Use `squashCommitMessage` only for `accept_complete`; when you return any non-accept action, set `squashCommitMessage` to null.
+- For `accept_complete`, provide a non-null object with one concise project-facing `subject` and 2 to 5 high-level `bullets`.
+- Do not mention plan paths, markdown plan filenames, temporary run paths, scope-numbered or per-scope wording, final cleanup, Neal mechanics, provider process, or reviewer process.
+- Summarize the code or product behavior change, not the plan document.
+- Valid example: subject "Persist final completion review failures"; bullets ["Mark invalid verdicts failed", "Record phase error events"].
+- Invalid example: subject "Finish scope 4 cleanup"; bullets ["Summarize per-scope plan work", "Describe reviewer process"].
+
+Coder whole-plan completion summary:
+{
+  "planGoalSatisfied": false,
+  "whatChangedOverall": "Canonical render matrix pinned across prompt specs.",
+  "verificationSummary": "pnpm typecheck",
+  "remainingKnownGaps": [
+    "One documentation pass remains."
+  ]
+}
+
+Whole-plan completion packet:
+{
+  "executionShape": "multi_scope",
+  "currentScopeLabel": "6",
+  "acceptedScopeRecordCount": 5,
+  "blockedScopeCount": 0,
+  "scopeAccountingSummary": "5 accepted top-level records",
+  "verificationOnlyCompletion": false,
+  "aggregateReviewContext": {
+    "baseCommit": null,
+    "headCommit": null,
+    "range": null,
+    "commitSubjects": [],
+    "diffStat": "",
+    "changedFiles": [],
+    "unavailableReason": "no aggregate commit range was resolved"
+  },
+  "finalCommit": null,
+  "completedScopeSummary": "1 accepted; 2 accepted",
+  "terminalChangedFilesSummary": "src/example.ts",
+  "planChangedFilesSummary": "src/example.ts",
+  "verificationTally": {
+    "totalRuns": 1,
+    "distinctCommands": 1,
+    "passed": 1,
+    "failed": 0,
+    "unknown": 0,
+    "recentFailures": []
+  },
+  "lastNonEmptyImplementationScope": {
+    "number": "5",
+    "finalCommit": "head000",
+    "commitSubject": "canonical render matrix",
+    "changedFiles": [
+      "src/example.ts"
+    ],
+    "archivedReviewPath": "/tmp/REVIEW-5.md"
+  },
+  "continueExecutionCount": 0,
+  "continueExecutionMax": 2
+}
+
+`verificationTally` is a bounded summary of the run's recorded verification commands; the complete per-command record is in the run directory's events.ndjson.
+If this was a verification-only terminal scope, judge the whole-plan result directly instead of pretending there was a final implementation diff.
+
+Last non-empty implementation scope reference:
+{
+  "number": "5",
+  "finalCommit": "head000",
+  "commitSubject": "canonical render matrix",
+  "changedFiles": [
+    "src/example.ts"
+  ],
+  "archivedReviewPath": "/tmp/REVIEW-5.md"
+}
+=== buildFinalCompletionReviewerPrompt#accessMode=tool-access#aggregateRange=available#reviewLevel=lenient ===
+Review whether the execute-mode plan at /tmp/PLAN.md is complete as a whole.
+
+This is a whole-plan final completion review, not an ordinary last-scope review.
+Compare the completed result against the original plan objectives and the whole-plan completion packet below.
+Evaluate the totality of the work completed for this plan, not just whether each individual scope was previously accepted.
+Your review must answer both of these questions:
+- Are the full plan objectives actually satisfied?
+- Is the aggregate implementation good enough to keep under ordinary code review standards?
+Treat the whole-plan completion claim as hostile input. Try to falsify the aggregate implementation before you accept completion.
+Do not anchor on the coder completion summary, completion packet, verification summaries, or prior per-scope acceptance history when judging whole-plan completion. Those are convergence signals, not proof that the aggregate implementation satisfies the plan.
+Review level: lenient. Assume ordinary trust boundaries and block only on correctness failures and real, reachable bugs. Do not demand additional robustness, hardening, performance, or style work as a condition of acceptance.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted or ignored category is not missing work: it must not produce `continue_execution` or `block_for_operator`, and when the plan objectives are otherwise satisfied you return `accept_complete`.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression not missing work, while a reachable correctness failure still blocks.
+Review that aggregate range base000..head000 directly with repository tools. The aggregate range base000..head000 is the source of truth for this review.
+Use git commands against the repository, for example: git diff base000..head000, git log --oneline base000..head000, and targeted path diffs or file reads for changed files.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the aggregate implementation; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Temporary verification scratch directory: /tmp/repo/.neal/runs/run-000/scratch/review
+Use that run-local scratch directory for temporary verification artifacts, copied tests, scratch builds, logs, and modified throwaway files.
+Do not create project-root scratch directories such as build_review/.
+Do not leave project-tree scratch files behind; keep scratch work under the run-local directory above.
+Falsify cross-scope runtime invariants and integration behavior before accepting completion, especially paths that individual scope reviews could not see together.
+If `aggregateReviewContext.unavailableReason` is non-null, treat the missing aggregate range as a completion-review evidence gap rather than proof that the aggregate implementation is correct.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the aggregate implementation.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the aggregate implementation touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — running them when available — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the aggregate implementation actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the aggregate implementation.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, exercise or reason through the affected existing flows directly — run the most relevant existing tests or reproduce the reported behavior when practical — rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Treat completion-blocking issues like review findings: each one needs concrete evidence, affected files or runtime behavior, and a required correction.
+Use `continue_execution` only for concrete missing work that is bounded enough for one follow-on scope; use `block_for_operator` for ambiguous or externally constrained gaps.
+A finding category that the review level or the User Guidance section has demoted or ignored is not missing work: never return `continue_execution` or `block_for_operator` for it. When the plan objectives are otherwise satisfied, return `accept_complete`.
+Do not turn low-signal style preferences, trivial code-shape preferences, or optional refactors into missing work.
+If the plan is complete aside from low-signal trivia, return `accept_complete` rather than inventing a non-blocking completion concern.
+Review the whole-plan result for correctness and completeness against the plan objectives, regressions or missing behavior, cross-scope integration issues that may not have been visible in individual scope reviews, code quality, maintainability, and consistency of the final implementation, and adequacy of test coverage and verification for the total change.
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+Do not treat prior per-scope acceptance as sufficient evidence that the whole plan is complete or that the aggregate code quality is acceptable.
+Return only JSON that matches the required schema.
+Return the final answer only as the required structured output object, not as prose or markdown.
+Defer exact output framing to the active structured-output transport; do not add your own output-format constraints.
+Use `accept_complete` only when the full plan objectives are satisfied and the aggregate implementation is acceptable under ordinary code review standards.
+Use `continue_execution` only when the remaining work is concrete, bounded, and suitable for one explicit follow-on scope.
+Use `block_for_operator` when the remaining gap is ambiguous, externally constrained, or needs human direction.
+When you return `continue_execution`, you must provide a non-null `missingWork` object with `summary`, `requiredOutcome`, and `verification`.
+When you return any other action, `missingWork` must be null.
+
+Squash commit message rules:
+- `squashCommitMessage` is project-facing Git history for human readers.
+- Use `squashCommitMessage` only for `accept_complete`; when you return any non-accept action, set `squashCommitMessage` to null.
+- For `accept_complete`, provide a non-null object with one concise project-facing `subject` and 2 to 5 high-level `bullets`.
+- Do not mention plan paths, markdown plan filenames, temporary run paths, scope-numbered or per-scope wording, final cleanup, Neal mechanics, provider process, or reviewer process.
+- Summarize the code or product behavior change, not the plan document.
+- Valid example: subject "Persist final completion review failures"; bullets ["Mark invalid verdicts failed", "Record phase error events"].
+- Invalid example: subject "Finish scope 4 cleanup"; bullets ["Summarize per-scope plan work", "Describe reviewer process"].
+
+Coder whole-plan completion summary:
+{
+  "planGoalSatisfied": false,
+  "whatChangedOverall": "Canonical render matrix pinned across prompt specs.",
+  "verificationSummary": "pnpm typecheck",
+  "remainingKnownGaps": [
+    "One documentation pass remains."
+  ]
+}
+
+Whole-plan completion packet:
+{
+  "executionShape": "multi_scope",
+  "currentScopeLabel": "6",
+  "acceptedScopeRecordCount": 5,
+  "blockedScopeCount": 0,
+  "scopeAccountingSummary": "5 accepted top-level records",
+  "verificationOnlyCompletion": false,
+  "aggregateReviewContext": {
+    "baseCommit": "base000",
+    "headCommit": "head000",
+    "range": "base000..head000",
+    "commitSubjects": [
+      "head000 canonical render matrix"
+    ],
+    "diffStat": " src/example.ts | 2 +-",
+    "changedFiles": [
+      "src/example.ts"
+    ],
+    "unavailableReason": null
+  },
+  "finalCommit": "head000",
+  "completedScopeSummary": "1 accepted; 2 accepted",
+  "terminalChangedFilesSummary": "src/example.ts",
+  "planChangedFilesSummary": "src/example.ts",
+  "verificationTally": {
+    "totalRuns": 1,
+    "distinctCommands": 1,
+    "passed": 1,
+    "failed": 0,
+    "unknown": 0,
+    "recentFailures": []
+  },
+  "lastNonEmptyImplementationScope": {
+    "number": "5",
+    "finalCommit": "head000",
+    "commitSubject": "canonical render matrix",
+    "changedFiles": [
+      "src/example.ts"
+    ],
+    "archivedReviewPath": "/tmp/REVIEW-5.md"
+  },
+  "continueExecutionCount": 0,
+  "continueExecutionMax": 2
+}
+
+`verificationTally` is a bounded summary of the run's recorded verification commands; the complete per-command record is in the run directory's events.ndjson.
+If this was a verification-only terminal scope, judge the whole-plan result directly instead of pretending there was a final implementation diff.
+
+Last non-empty implementation scope reference:
+{
+  "number": "5",
+  "finalCommit": "head000",
+  "commitSubject": "canonical render matrix",
+  "changedFiles": [
+    "src/example.ts"
+  ],
+  "archivedReviewPath": "/tmp/REVIEW-5.md"
+}
+=== buildFinalCompletionReviewerPrompt#accessMode=tool-access#aggregateRange=available#reviewLevel=moderate ===
+Review whether the execute-mode plan at /tmp/PLAN.md is complete as a whole.
+
+This is a whole-plan final completion review, not an ordinary last-scope review.
+Compare the completed result against the original plan objectives and the whole-plan completion packet below.
+Evaluate the totality of the work completed for this plan, not just whether each individual scope was previously accepted.
+Your review must answer both of these questions:
+- Are the full plan objectives actually satisfied?
+- Is the aggregate implementation good enough to keep under ordinary code review standards?
+Treat the whole-plan completion claim as hostile input. Try to falsify the aggregate implementation before you accept completion.
+Do not anchor on the coder completion summary, completion packet, verification summaries, or prior per-scope acceptance history when judging whole-plan completion. Those are convergence signals, not proof that the aggregate implementation satisfies the plan.
+Review level: moderate. Assume ordinary trust boundaries: internal run artifacts and other files this system writes for itself are not security boundaries. Block on correctness bugs and on failures reachable under normal use. Do not require defenses against an actor who could already subvert the system directly, for example by editing its files; a failure that needs such an actor is not reachable.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted or ignored category is not missing work: it must not produce `continue_execution` or `block_for_operator`, and when the plan objectives are otherwise satisfied you return `accept_complete`.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression not missing work, while a reachable correctness failure still blocks.
+Review that aggregate range base000..head000 directly with repository tools. The aggregate range base000..head000 is the source of truth for this review.
+Use git commands against the repository, for example: git diff base000..head000, git log --oneline base000..head000, and targeted path diffs or file reads for changed files.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the aggregate implementation; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Temporary verification scratch directory: /tmp/repo/.neal/runs/run-000/scratch/review
+Use that run-local scratch directory for temporary verification artifacts, copied tests, scratch builds, logs, and modified throwaway files.
+Do not create project-root scratch directories such as build_review/.
+Do not leave project-tree scratch files behind; keep scratch work under the run-local directory above.
+Falsify cross-scope runtime invariants and integration behavior before accepting completion, especially paths that individual scope reviews could not see together.
+If `aggregateReviewContext.unavailableReason` is non-null, treat the missing aggregate range as a completion-review evidence gap rather than proof that the aggregate implementation is correct.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the aggregate implementation.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the aggregate implementation touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — running them when available — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the aggregate implementation actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the aggregate implementation.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, exercise or reason through the affected existing flows directly — run the most relevant existing tests or reproduce the reported behavior when practical — rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Treat completion-blocking issues like review findings: each one needs concrete evidence, affected files or runtime behavior, and a required correction.
+Use `continue_execution` only for concrete missing work that is bounded enough for one follow-on scope; use `block_for_operator` for ambiguous or externally constrained gaps.
+A finding category that the review level or the User Guidance section has demoted or ignored is not missing work: never return `continue_execution` or `block_for_operator` for it. When the plan objectives are otherwise satisfied, return `accept_complete`.
+Do not turn low-signal style preferences, trivial code-shape preferences, or optional refactors into missing work.
+If the plan is complete aside from low-signal trivia, return `accept_complete` rather than inventing a non-blocking completion concern.
+Review the whole-plan result for correctness and completeness against the plan objectives, regressions or missing behavior, cross-scope integration issues that may not have been visible in individual scope reviews, code quality, maintainability, and consistency of the final implementation, and adequacy of test coverage and verification for the total change.
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+Do not treat prior per-scope acceptance as sufficient evidence that the whole plan is complete or that the aggregate code quality is acceptable.
+Return only JSON that matches the required schema.
+Return the final answer only as the required structured output object, not as prose or markdown.
+Defer exact output framing to the active structured-output transport; do not add your own output-format constraints.
+Use `accept_complete` only when the full plan objectives are satisfied and the aggregate implementation is acceptable under ordinary code review standards.
+Use `continue_execution` only when the remaining work is concrete, bounded, and suitable for one explicit follow-on scope.
+Use `block_for_operator` when the remaining gap is ambiguous, externally constrained, or needs human direction.
+When you return `continue_execution`, you must provide a non-null `missingWork` object with `summary`, `requiredOutcome`, and `verification`.
+When you return any other action, `missingWork` must be null.
+
+Squash commit message rules:
+- `squashCommitMessage` is project-facing Git history for human readers.
+- Use `squashCommitMessage` only for `accept_complete`; when you return any non-accept action, set `squashCommitMessage` to null.
+- For `accept_complete`, provide a non-null object with one concise project-facing `subject` and 2 to 5 high-level `bullets`.
+- Do not mention plan paths, markdown plan filenames, temporary run paths, scope-numbered or per-scope wording, final cleanup, Neal mechanics, provider process, or reviewer process.
+- Summarize the code or product behavior change, not the plan document.
+- Valid example: subject "Persist final completion review failures"; bullets ["Mark invalid verdicts failed", "Record phase error events"].
+- Invalid example: subject "Finish scope 4 cleanup"; bullets ["Summarize per-scope plan work", "Describe reviewer process"].
+
+Coder whole-plan completion summary:
+{
+  "planGoalSatisfied": false,
+  "whatChangedOverall": "Canonical render matrix pinned across prompt specs.",
+  "verificationSummary": "pnpm typecheck",
+  "remainingKnownGaps": [
+    "One documentation pass remains."
+  ]
+}
+
+Whole-plan completion packet:
+{
+  "executionShape": "multi_scope",
+  "currentScopeLabel": "6",
+  "acceptedScopeRecordCount": 5,
+  "blockedScopeCount": 0,
+  "scopeAccountingSummary": "5 accepted top-level records",
+  "verificationOnlyCompletion": false,
+  "aggregateReviewContext": {
+    "baseCommit": "base000",
+    "headCommit": "head000",
+    "range": "base000..head000",
+    "commitSubjects": [
+      "head000 canonical render matrix"
+    ],
+    "diffStat": " src/example.ts | 2 +-",
+    "changedFiles": [
+      "src/example.ts"
+    ],
+    "unavailableReason": null
+  },
+  "finalCommit": "head000",
+  "completedScopeSummary": "1 accepted; 2 accepted",
+  "terminalChangedFilesSummary": "src/example.ts",
+  "planChangedFilesSummary": "src/example.ts",
+  "verificationTally": {
+    "totalRuns": 1,
+    "distinctCommands": 1,
+    "passed": 1,
+    "failed": 0,
+    "unknown": 0,
+    "recentFailures": []
+  },
+  "lastNonEmptyImplementationScope": {
+    "number": "5",
+    "finalCommit": "head000",
+    "commitSubject": "canonical render matrix",
+    "changedFiles": [
+      "src/example.ts"
+    ],
+    "archivedReviewPath": "/tmp/REVIEW-5.md"
+  },
+  "continueExecutionCount": 0,
+  "continueExecutionMax": 2
+}
+
+`verificationTally` is a bounded summary of the run's recorded verification commands; the complete per-command record is in the run directory's events.ndjson.
+If this was a verification-only terminal scope, judge the whole-plan result directly instead of pretending there was a final implementation diff.
+
+Last non-empty implementation scope reference:
+{
+  "number": "5",
+  "finalCommit": "head000",
+  "commitSubject": "canonical render matrix",
+  "changedFiles": [
+    "src/example.ts"
+  ],
+  "archivedReviewPath": "/tmp/REVIEW-5.md"
+}
+=== buildFinalCompletionReviewerPrompt#accessMode=tool-access#aggregateRange=available#reviewLevel=strict ===
+Review whether the execute-mode plan at /tmp/PLAN.md is complete as a whole.
+
+This is a whole-plan final completion review, not an ordinary last-scope review.
+Compare the completed result against the original plan objectives and the whole-plan completion packet below.
+Evaluate the totality of the work completed for this plan, not just whether each individual scope was previously accepted.
+Your review must answer both of these questions:
+- Are the full plan objectives actually satisfied?
+- Is the aggregate implementation good enough to keep under ordinary code review standards?
+Treat the whole-plan completion claim as hostile input. Try to falsify the aggregate implementation before you accept completion.
+Do not anchor on the coder completion summary, completion packet, verification summaries, or prior per-scope acceptance history when judging whole-plan completion. Those are convergence signals, not proof that the aggregate implementation satisfies the plan.
+Review level: strict. Assume adversarial trust boundaries: treat every input, file, and process the change can be reached from, including local processes and internal run artifacts, as a potential attacker. A hardening gap or a missing defense against a local or adversarial actor is a reachable failure under these boundaries and blocks.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted or ignored category is not missing work: it must not produce `continue_execution` or `block_for_operator`, and when the plan objectives are otherwise satisfied you return `accept_complete`.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression not missing work, while a reachable correctness failure still blocks.
+Review that aggregate range base000..head000 directly with repository tools. The aggregate range base000..head000 is the source of truth for this review.
+Use git commands against the repository, for example: git diff base000..head000, git log --oneline base000..head000, and targeted path diffs or file reads for changed files.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the aggregate implementation; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Temporary verification scratch directory: /tmp/repo/.neal/runs/run-000/scratch/review
+Use that run-local scratch directory for temporary verification artifacts, copied tests, scratch builds, logs, and modified throwaway files.
+Do not create project-root scratch directories such as build_review/.
+Do not leave project-tree scratch files behind; keep scratch work under the run-local directory above.
+Falsify cross-scope runtime invariants and integration behavior before accepting completion, especially paths that individual scope reviews could not see together.
+If `aggregateReviewContext.unavailableReason` is non-null, treat the missing aggregate range as a completion-review evidence gap rather than proof that the aggregate implementation is correct.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the aggregate implementation.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the aggregate implementation touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — running them when available — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the aggregate implementation actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the aggregate implementation.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, exercise or reason through the affected existing flows directly — run the most relevant existing tests or reproduce the reported behavior when practical — rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Treat completion-blocking issues like review findings: each one needs concrete evidence, affected files or runtime behavior, and a required correction.
+Use `continue_execution` only for concrete missing work that is bounded enough for one follow-on scope; use `block_for_operator` for ambiguous or externally constrained gaps.
+A finding category that the review level or the User Guidance section has demoted or ignored is not missing work: never return `continue_execution` or `block_for_operator` for it. When the plan objectives are otherwise satisfied, return `accept_complete`.
+Do not turn low-signal style preferences, trivial code-shape preferences, or optional refactors into missing work.
+If the plan is complete aside from low-signal trivia, return `accept_complete` rather than inventing a non-blocking completion concern.
+Review the whole-plan result for correctness and completeness against the plan objectives, regressions or missing behavior, cross-scope integration issues that may not have been visible in individual scope reviews, code quality, maintainability, and consistency of the final implementation, and adequacy of test coverage and verification for the total change.
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+Do not treat prior per-scope acceptance as sufficient evidence that the whole plan is complete or that the aggregate code quality is acceptable.
+Return only JSON that matches the required schema.
+Return the final answer only as the required structured output object, not as prose or markdown.
+Defer exact output framing to the active structured-output transport; do not add your own output-format constraints.
+Use `accept_complete` only when the full plan objectives are satisfied and the aggregate implementation is acceptable under ordinary code review standards.
+Use `continue_execution` only when the remaining work is concrete, bounded, and suitable for one explicit follow-on scope.
+Use `block_for_operator` when the remaining gap is ambiguous, externally constrained, or needs human direction.
+When you return `continue_execution`, you must provide a non-null `missingWork` object with `summary`, `requiredOutcome`, and `verification`.
+When you return any other action, `missingWork` must be null.
+
+Squash commit message rules:
+- `squashCommitMessage` is project-facing Git history for human readers.
+- Use `squashCommitMessage` only for `accept_complete`; when you return any non-accept action, set `squashCommitMessage` to null.
+- For `accept_complete`, provide a non-null object with one concise project-facing `subject` and 2 to 5 high-level `bullets`.
+- Do not mention plan paths, markdown plan filenames, temporary run paths, scope-numbered or per-scope wording, final cleanup, Neal mechanics, provider process, or reviewer process.
+- Summarize the code or product behavior change, not the plan document.
+- Valid example: subject "Persist final completion review failures"; bullets ["Mark invalid verdicts failed", "Record phase error events"].
+- Invalid example: subject "Finish scope 4 cleanup"; bullets ["Summarize per-scope plan work", "Describe reviewer process"].
+
+Coder whole-plan completion summary:
+{
+  "planGoalSatisfied": false,
+  "whatChangedOverall": "Canonical render matrix pinned across prompt specs.",
+  "verificationSummary": "pnpm typecheck",
+  "remainingKnownGaps": [
+    "One documentation pass remains."
+  ]
+}
+
+Whole-plan completion packet:
+{
+  "executionShape": "multi_scope",
+  "currentScopeLabel": "6",
+  "acceptedScopeRecordCount": 5,
+  "blockedScopeCount": 0,
+  "scopeAccountingSummary": "5 accepted top-level records",
+  "verificationOnlyCompletion": false,
+  "aggregateReviewContext": {
+    "baseCommit": "base000",
+    "headCommit": "head000",
+    "range": "base000..head000",
+    "commitSubjects": [
+      "head000 canonical render matrix"
+    ],
+    "diffStat": " src/example.ts | 2 +-",
+    "changedFiles": [
+      "src/example.ts"
+    ],
+    "unavailableReason": null
+  },
+  "finalCommit": "head000",
+  "completedScopeSummary": "1 accepted; 2 accepted",
+  "terminalChangedFilesSummary": "src/example.ts",
+  "planChangedFilesSummary": "src/example.ts",
+  "verificationTally": {
+    "totalRuns": 1,
+    "distinctCommands": 1,
+    "passed": 1,
+    "failed": 0,
+    "unknown": 0,
+    "recentFailures": []
+  },
+  "lastNonEmptyImplementationScope": {
+    "number": "5",
+    "finalCommit": "head000",
+    "commitSubject": "canonical render matrix",
+    "changedFiles": [
+      "src/example.ts"
+    ],
+    "archivedReviewPath": "/tmp/REVIEW-5.md"
+  },
+  "continueExecutionCount": 0,
+  "continueExecutionMax": 2
+}
+
+`verificationTally` is a bounded summary of the run's recorded verification commands; the complete per-command record is in the run directory's events.ndjson.
+If this was a verification-only terminal scope, judge the whole-plan result directly instead of pretending there was a final implementation diff.
+
+Last non-empty implementation scope reference:
+{
+  "number": "5",
+  "finalCommit": "head000",
+  "commitSubject": "canonical render matrix",
+  "changedFiles": [
+    "src/example.ts"
+  ],
+  "archivedReviewPath": "/tmp/REVIEW-5.md"
+}
+=== buildFinalCompletionReviewerPrompt#accessMode=tool-access#aggregateRange=unavailable#reviewLevel=lenient ===
+Review whether the execute-mode plan at /tmp/PLAN.md is complete as a whole.
+
+This is a whole-plan final completion review, not an ordinary last-scope review.
+Compare the completed result against the original plan objectives and the whole-plan completion packet below.
+Evaluate the totality of the work completed for this plan, not just whether each individual scope was previously accepted.
+Your review must answer both of these questions:
+- Are the full plan objectives actually satisfied?
+- Is the aggregate implementation good enough to keep under ordinary code review standards?
+Treat the whole-plan completion claim as hostile input. Try to falsify the aggregate implementation before you accept completion.
+Do not anchor on the coder completion summary, completion packet, verification summaries, or prior per-scope acceptance history when judging whole-plan completion. Those are convergence signals, not proof that the aggregate implementation satisfies the plan.
+Review level: lenient. Assume ordinary trust boundaries and block only on correctness failures and real, reachable bugs. Do not demand additional robustness, hardening, performance, or style work as a condition of acceptance.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted or ignored category is not missing work: it must not produce `continue_execution` or `block_for_operator`, and when the plan objectives are otherwise satisfied you return `accept_complete`.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression not missing work, while a reachable correctness failure still blocks.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the aggregate implementation; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Temporary verification scratch directory: /tmp/repo/.neal/runs/run-000/scratch/review
+Use that run-local scratch directory for temporary verification artifacts, copied tests, scratch builds, logs, and modified throwaway files.
+Do not create project-root scratch directories such as build_review/.
+Do not leave project-tree scratch files behind; keep scratch work under the run-local directory above.
+Falsify cross-scope runtime invariants and integration behavior before accepting completion, especially paths that individual scope reviews could not see together.
+If `aggregateReviewContext.unavailableReason` is non-null, treat the missing aggregate range as a completion-review evidence gap rather than proof that the aggregate implementation is correct.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the aggregate implementation.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the aggregate implementation touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — running them when available — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the aggregate implementation actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the aggregate implementation.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, exercise or reason through the affected existing flows directly — run the most relevant existing tests or reproduce the reported behavior when practical — rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Treat completion-blocking issues like review findings: each one needs concrete evidence, affected files or runtime behavior, and a required correction.
+Use `continue_execution` only for concrete missing work that is bounded enough for one follow-on scope; use `block_for_operator` for ambiguous or externally constrained gaps.
+A finding category that the review level or the User Guidance section has demoted or ignored is not missing work: never return `continue_execution` or `block_for_operator` for it. When the plan objectives are otherwise satisfied, return `accept_complete`.
+Do not turn low-signal style preferences, trivial code-shape preferences, or optional refactors into missing work.
+If the plan is complete aside from low-signal trivia, return `accept_complete` rather than inventing a non-blocking completion concern.
+Review the whole-plan result for correctness and completeness against the plan objectives, regressions or missing behavior, cross-scope integration issues that may not have been visible in individual scope reviews, code quality, maintainability, and consistency of the final implementation, and adequacy of test coverage and verification for the total change.
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+Do not treat prior per-scope acceptance as sufficient evidence that the whole plan is complete or that the aggregate code quality is acceptable.
+Return only JSON that matches the required schema.
+Return the final answer only as the required structured output object, not as prose or markdown.
+Defer exact output framing to the active structured-output transport; do not add your own output-format constraints.
+Use `accept_complete` only when the full plan objectives are satisfied and the aggregate implementation is acceptable under ordinary code review standards.
+Use `continue_execution` only when the remaining work is concrete, bounded, and suitable for one explicit follow-on scope.
+Use `block_for_operator` when the remaining gap is ambiguous, externally constrained, or needs human direction.
+When you return `continue_execution`, you must provide a non-null `missingWork` object with `summary`, `requiredOutcome`, and `verification`.
+When you return any other action, `missingWork` must be null.
+
+Squash commit message rules:
+- `squashCommitMessage` is project-facing Git history for human readers.
+- Use `squashCommitMessage` only for `accept_complete`; when you return any non-accept action, set `squashCommitMessage` to null.
+- For `accept_complete`, provide a non-null object with one concise project-facing `subject` and 2 to 5 high-level `bullets`.
+- Do not mention plan paths, markdown plan filenames, temporary run paths, scope-numbered or per-scope wording, final cleanup, Neal mechanics, provider process, or reviewer process.
+- Summarize the code or product behavior change, not the plan document.
+- Valid example: subject "Persist final completion review failures"; bullets ["Mark invalid verdicts failed", "Record phase error events"].
+- Invalid example: subject "Finish scope 4 cleanup"; bullets ["Summarize per-scope plan work", "Describe reviewer process"].
+
+Coder whole-plan completion summary:
+{
+  "planGoalSatisfied": false,
+  "whatChangedOverall": "Canonical render matrix pinned across prompt specs.",
+  "verificationSummary": "pnpm typecheck",
+  "remainingKnownGaps": [
+    "One documentation pass remains."
+  ]
+}
+
+Whole-plan completion packet:
+{
+  "executionShape": "multi_scope",
+  "currentScopeLabel": "6",
+  "acceptedScopeRecordCount": 5,
+  "blockedScopeCount": 0,
+  "scopeAccountingSummary": "5 accepted top-level records",
+  "verificationOnlyCompletion": false,
+  "aggregateReviewContext": {
+    "baseCommit": null,
+    "headCommit": null,
+    "range": null,
+    "commitSubjects": [],
+    "diffStat": "",
+    "changedFiles": [],
+    "unavailableReason": "no aggregate commit range was resolved"
+  },
+  "finalCommit": null,
+  "completedScopeSummary": "1 accepted; 2 accepted",
+  "terminalChangedFilesSummary": "src/example.ts",
+  "planChangedFilesSummary": "src/example.ts",
+  "verificationTally": {
+    "totalRuns": 1,
+    "distinctCommands": 1,
+    "passed": 1,
+    "failed": 0,
+    "unknown": 0,
+    "recentFailures": []
+  },
+  "lastNonEmptyImplementationScope": {
+    "number": "5",
+    "finalCommit": "head000",
+    "commitSubject": "canonical render matrix",
+    "changedFiles": [
+      "src/example.ts"
+    ],
+    "archivedReviewPath": "/tmp/REVIEW-5.md"
+  },
+  "continueExecutionCount": 0,
+  "continueExecutionMax": 2
+}
+
+`verificationTally` is a bounded summary of the run's recorded verification commands; the complete per-command record is in the run directory's events.ndjson.
+If this was a verification-only terminal scope, judge the whole-plan result directly instead of pretending there was a final implementation diff.
+
+Last non-empty implementation scope reference:
+{
+  "number": "5",
+  "finalCommit": "head000",
+  "commitSubject": "canonical render matrix",
+  "changedFiles": [
+    "src/example.ts"
+  ],
+  "archivedReviewPath": "/tmp/REVIEW-5.md"
+}
+=== buildFinalCompletionReviewerPrompt#accessMode=tool-access#aggregateRange=unavailable#reviewLevel=moderate ===
+Review whether the execute-mode plan at /tmp/PLAN.md is complete as a whole.
+
+This is a whole-plan final completion review, not an ordinary last-scope review.
+Compare the completed result against the original plan objectives and the whole-plan completion packet below.
+Evaluate the totality of the work completed for this plan, not just whether each individual scope was previously accepted.
+Your review must answer both of these questions:
+- Are the full plan objectives actually satisfied?
+- Is the aggregate implementation good enough to keep under ordinary code review standards?
+Treat the whole-plan completion claim as hostile input. Try to falsify the aggregate implementation before you accept completion.
+Do not anchor on the coder completion summary, completion packet, verification summaries, or prior per-scope acceptance history when judging whole-plan completion. Those are convergence signals, not proof that the aggregate implementation satisfies the plan.
+Review level: moderate. Assume ordinary trust boundaries: internal run artifacts and other files this system writes for itself are not security boundaries. Block on correctness bugs and on failures reachable under normal use. Do not require defenses against an actor who could already subvert the system directly, for example by editing its files; a failure that needs such an actor is not reachable.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted or ignored category is not missing work: it must not produce `continue_execution` or `block_for_operator`, and when the plan objectives are otherwise satisfied you return `accept_complete`.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression not missing work, while a reachable correctness failure still blocks.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the aggregate implementation; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Temporary verification scratch directory: /tmp/repo/.neal/runs/run-000/scratch/review
+Use that run-local scratch directory for temporary verification artifacts, copied tests, scratch builds, logs, and modified throwaway files.
+Do not create project-root scratch directories such as build_review/.
+Do not leave project-tree scratch files behind; keep scratch work under the run-local directory above.
+Falsify cross-scope runtime invariants and integration behavior before accepting completion, especially paths that individual scope reviews could not see together.
+If `aggregateReviewContext.unavailableReason` is non-null, treat the missing aggregate range as a completion-review evidence gap rather than proof that the aggregate implementation is correct.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the aggregate implementation.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the aggregate implementation touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — running them when available — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the aggregate implementation actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the aggregate implementation.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, exercise or reason through the affected existing flows directly — run the most relevant existing tests or reproduce the reported behavior when practical — rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Treat completion-blocking issues like review findings: each one needs concrete evidence, affected files or runtime behavior, and a required correction.
+Use `continue_execution` only for concrete missing work that is bounded enough for one follow-on scope; use `block_for_operator` for ambiguous or externally constrained gaps.
+A finding category that the review level or the User Guidance section has demoted or ignored is not missing work: never return `continue_execution` or `block_for_operator` for it. When the plan objectives are otherwise satisfied, return `accept_complete`.
+Do not turn low-signal style preferences, trivial code-shape preferences, or optional refactors into missing work.
+If the plan is complete aside from low-signal trivia, return `accept_complete` rather than inventing a non-blocking completion concern.
+Review the whole-plan result for correctness and completeness against the plan objectives, regressions or missing behavior, cross-scope integration issues that may not have been visible in individual scope reviews, code quality, maintainability, and consistency of the final implementation, and adequacy of test coverage and verification for the total change.
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+Do not treat prior per-scope acceptance as sufficient evidence that the whole plan is complete or that the aggregate code quality is acceptable.
+Return only JSON that matches the required schema.
+Return the final answer only as the required structured output object, not as prose or markdown.
+Defer exact output framing to the active structured-output transport; do not add your own output-format constraints.
+Use `accept_complete` only when the full plan objectives are satisfied and the aggregate implementation is acceptable under ordinary code review standards.
+Use `continue_execution` only when the remaining work is concrete, bounded, and suitable for one explicit follow-on scope.
+Use `block_for_operator` when the remaining gap is ambiguous, externally constrained, or needs human direction.
+When you return `continue_execution`, you must provide a non-null `missingWork` object with `summary`, `requiredOutcome`, and `verification`.
+When you return any other action, `missingWork` must be null.
+
+Squash commit message rules:
+- `squashCommitMessage` is project-facing Git history for human readers.
+- Use `squashCommitMessage` only for `accept_complete`; when you return any non-accept action, set `squashCommitMessage` to null.
+- For `accept_complete`, provide a non-null object with one concise project-facing `subject` and 2 to 5 high-level `bullets`.
+- Do not mention plan paths, markdown plan filenames, temporary run paths, scope-numbered or per-scope wording, final cleanup, Neal mechanics, provider process, or reviewer process.
+- Summarize the code or product behavior change, not the plan document.
+- Valid example: subject "Persist final completion review failures"; bullets ["Mark invalid verdicts failed", "Record phase error events"].
+- Invalid example: subject "Finish scope 4 cleanup"; bullets ["Summarize per-scope plan work", "Describe reviewer process"].
+
+Coder whole-plan completion summary:
+{
+  "planGoalSatisfied": false,
+  "whatChangedOverall": "Canonical render matrix pinned across prompt specs.",
+  "verificationSummary": "pnpm typecheck",
+  "remainingKnownGaps": [
+    "One documentation pass remains."
+  ]
+}
+
+Whole-plan completion packet:
+{
+  "executionShape": "multi_scope",
+  "currentScopeLabel": "6",
+  "acceptedScopeRecordCount": 5,
+  "blockedScopeCount": 0,
+  "scopeAccountingSummary": "5 accepted top-level records",
+  "verificationOnlyCompletion": false,
+  "aggregateReviewContext": {
+    "baseCommit": null,
+    "headCommit": null,
+    "range": null,
+    "commitSubjects": [],
+    "diffStat": "",
+    "changedFiles": [],
+    "unavailableReason": "no aggregate commit range was resolved"
+  },
+  "finalCommit": null,
+  "completedScopeSummary": "1 accepted; 2 accepted",
+  "terminalChangedFilesSummary": "src/example.ts",
+  "planChangedFilesSummary": "src/example.ts",
+  "verificationTally": {
+    "totalRuns": 1,
+    "distinctCommands": 1,
+    "passed": 1,
+    "failed": 0,
+    "unknown": 0,
+    "recentFailures": []
+  },
+  "lastNonEmptyImplementationScope": {
+    "number": "5",
+    "finalCommit": "head000",
+    "commitSubject": "canonical render matrix",
+    "changedFiles": [
+      "src/example.ts"
+    ],
+    "archivedReviewPath": "/tmp/REVIEW-5.md"
+  },
+  "continueExecutionCount": 0,
+  "continueExecutionMax": 2
+}
+
+`verificationTally` is a bounded summary of the run's recorded verification commands; the complete per-command record is in the run directory's events.ndjson.
+If this was a verification-only terminal scope, judge the whole-plan result directly instead of pretending there was a final implementation diff.
+
+Last non-empty implementation scope reference:
+{
+  "number": "5",
+  "finalCommit": "head000",
+  "commitSubject": "canonical render matrix",
+  "changedFiles": [
+    "src/example.ts"
+  ],
+  "archivedReviewPath": "/tmp/REVIEW-5.md"
+}
+=== buildFinalCompletionReviewerPrompt#accessMode=tool-access#aggregateRange=unavailable#reviewLevel=strict ===
+Review whether the execute-mode plan at /tmp/PLAN.md is complete as a whole.
+
+This is a whole-plan final completion review, not an ordinary last-scope review.
+Compare the completed result against the original plan objectives and the whole-plan completion packet below.
+Evaluate the totality of the work completed for this plan, not just whether each individual scope was previously accepted.
+Your review must answer both of these questions:
+- Are the full plan objectives actually satisfied?
+- Is the aggregate implementation good enough to keep under ordinary code review standards?
+Treat the whole-plan completion claim as hostile input. Try to falsify the aggregate implementation before you accept completion.
+Do not anchor on the coder completion summary, completion packet, verification summaries, or prior per-scope acceptance history when judging whole-plan completion. Those are convergence signals, not proof that the aggregate implementation satisfies the plan.
+Review level: strict. Assume adversarial trust boundaries: treat every input, file, and process the change can be reached from, including local processes and internal run artifacts, as a potential attacker. A hardening gap or a missing defense against a local or adversarial actor is a reachable failure under these boundaries and blocks.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted or ignored category is not missing work: it must not produce `continue_execution` or `block_for_operator`, and when the plan objectives are otherwise satisfied you return `accept_complete`.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression not missing work, while a reachable correctness failure still blocks.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the aggregate implementation; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Temporary verification scratch directory: /tmp/repo/.neal/runs/run-000/scratch/review
+Use that run-local scratch directory for temporary verification artifacts, copied tests, scratch builds, logs, and modified throwaway files.
+Do not create project-root scratch directories such as build_review/.
+Do not leave project-tree scratch files behind; keep scratch work under the run-local directory above.
+Falsify cross-scope runtime invariants and integration behavior before accepting completion, especially paths that individual scope reviews could not see together.
+If `aggregateReviewContext.unavailableReason` is non-null, treat the missing aggregate range as a completion-review evidence gap rather than proof that the aggregate implementation is correct.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the aggregate implementation.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the aggregate implementation touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — running them when available — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the aggregate implementation actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the aggregate implementation.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, exercise or reason through the affected existing flows directly — run the most relevant existing tests or reproduce the reported behavior when practical — rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Treat completion-blocking issues like review findings: each one needs concrete evidence, affected files or runtime behavior, and a required correction.
+Use `continue_execution` only for concrete missing work that is bounded enough for one follow-on scope; use `block_for_operator` for ambiguous or externally constrained gaps.
+A finding category that the review level or the User Guidance section has demoted or ignored is not missing work: never return `continue_execution` or `block_for_operator` for it. When the plan objectives are otherwise satisfied, return `accept_complete`.
+Do not turn low-signal style preferences, trivial code-shape preferences, or optional refactors into missing work.
+If the plan is complete aside from low-signal trivia, return `accept_complete` rather than inventing a non-blocking completion concern.
+Review the whole-plan result for correctness and completeness against the plan objectives, regressions or missing behavior, cross-scope integration issues that may not have been visible in individual scope reviews, code quality, maintainability, and consistency of the final implementation, and adequacy of test coverage and verification for the total change.
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+Do not treat prior per-scope acceptance as sufficient evidence that the whole plan is complete or that the aggregate code quality is acceptable.
+Return only JSON that matches the required schema.
+Return the final answer only as the required structured output object, not as prose or markdown.
+Defer exact output framing to the active structured-output transport; do not add your own output-format constraints.
+Use `accept_complete` only when the full plan objectives are satisfied and the aggregate implementation is acceptable under ordinary code review standards.
+Use `continue_execution` only when the remaining work is concrete, bounded, and suitable for one explicit follow-on scope.
+Use `block_for_operator` when the remaining gap is ambiguous, externally constrained, or needs human direction.
+When you return `continue_execution`, you must provide a non-null `missingWork` object with `summary`, `requiredOutcome`, and `verification`.
+When you return any other action, `missingWork` must be null.
+
+Squash commit message rules:
+- `squashCommitMessage` is project-facing Git history for human readers.
+- Use `squashCommitMessage` only for `accept_complete`; when you return any non-accept action, set `squashCommitMessage` to null.
+- For `accept_complete`, provide a non-null object with one concise project-facing `subject` and 2 to 5 high-level `bullets`.
+- Do not mention plan paths, markdown plan filenames, temporary run paths, scope-numbered or per-scope wording, final cleanup, Neal mechanics, provider process, or reviewer process.
+- Summarize the code or product behavior change, not the plan document.
+- Valid example: subject "Persist final completion review failures"; bullets ["Mark invalid verdicts failed", "Record phase error events"].
+- Invalid example: subject "Finish scope 4 cleanup"; bullets ["Summarize per-scope plan work", "Describe reviewer process"].
+
+Coder whole-plan completion summary:
+{
+  "planGoalSatisfied": false,
+  "whatChangedOverall": "Canonical render matrix pinned across prompt specs.",
+  "verificationSummary": "pnpm typecheck",
+  "remainingKnownGaps": [
+    "One documentation pass remains."
+  ]
+}
+
+Whole-plan completion packet:
+{
+  "executionShape": "multi_scope",
+  "currentScopeLabel": "6",
+  "acceptedScopeRecordCount": 5,
+  "blockedScopeCount": 0,
+  "scopeAccountingSummary": "5 accepted top-level records",
+  "verificationOnlyCompletion": false,
+  "aggregateReviewContext": {
+    "baseCommit": null,
+    "headCommit": null,
+    "range": null,
+    "commitSubjects": [],
+    "diffStat": "",
+    "changedFiles": [],
+    "unavailableReason": "no aggregate commit range was resolved"
+  },
+  "finalCommit": null,
+  "completedScopeSummary": "1 accepted; 2 accepted",
+  "terminalChangedFilesSummary": "src/example.ts",
+  "planChangedFilesSummary": "src/example.ts",
+  "verificationTally": {
+    "totalRuns": 1,
+    "distinctCommands": 1,
+    "passed": 1,
+    "failed": 0,
+    "unknown": 0,
+    "recentFailures": []
+  },
+  "lastNonEmptyImplementationScope": {
+    "number": "5",
+    "finalCommit": "head000",
+    "commitSubject": "canonical render matrix",
+    "changedFiles": [
+      "src/example.ts"
+    ],
+    "archivedReviewPath": "/tmp/REVIEW-5.md"
+  },
+  "continueExecutionCount": 0,
+  "continueExecutionMax": 2
+}
+
+`verificationTally` is a bounded summary of the run's recorded verification commands; the complete per-command record is in the run directory's events.ndjson.
+If this was a verification-only terminal scope, judge the whole-plan result directly instead of pretending there was a final implementation diff.
+
+Last non-empty implementation scope reference:
+{
+  "number": "5",
+  "finalCommit": "head000",
+  "commitSubject": "canonical render matrix",
+  "changedFiles": [
+    "src/example.ts"
+  ],
+  "archivedReviewPath": "/tmp/REVIEW-5.md"
+}

--- a/test/fixtures/prompts/render-integrity/scope_reviewer.v5.txt
+++ b/test/fixtures/prompts/render-integrity/scope_reviewer.v5.txt
@@ -1,0 +1,4722 @@
+=== buildReviewerPrompt#accessMode=read-only-inlined#earlierScopeChanges=absent#previousHead=absent#reviewLevel=lenient ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+The commit-range diff for that commit range is inlined below and is the source of truth for exactly what the commit range changed (including deletions and renames). Use your read tools to verify the surrounding code; you have no commit-range diff tool, so rely on the inlined diff for what changed.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Inspect the change using the inlined commit-range diff below for what changed (including deletions and renames), then read the changed files in full with your read tools and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: lenient. Assume ordinary trust boundaries and block only on correctness failures and real, reachable bugs. Do not demand additional robustness, hardening, performance, or style work as a condition of acceptance.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Robustness or performance regressions introduced by the implementation are non_blocking unless they are a reachable correctness failure; use blocking severity only in that case.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+This is the first reviewer round for this scope.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+
+## Inlined commit-range diff from Neal (base000..head000)
+
+You have read-only repository tools (read and search, no shell) but no commit-range diff tool, so Neal has inlined the commit-range diff below.
+This inlined diff is the source of truth for exactly what this range changed, including deletions and renames that head-state file reads cannot reveal. Use your read tools to verify the surrounding code.
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-old
++new
+
+=== buildReviewerPrompt#accessMode=read-only-inlined#earlierScopeChanges=absent#previousHead=absent#reviewLevel=moderate ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+The commit-range diff for that commit range is inlined below and is the source of truth for exactly what the commit range changed (including deletions and renames). Use your read tools to verify the surrounding code; you have no commit-range diff tool, so rely on the inlined diff for what changed.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Inspect the change using the inlined commit-range diff below for what changed (including deletions and renames), then read the changed files in full with your read tools and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: moderate. Assume ordinary trust boundaries: internal run artifacts and other files this system writes for itself are not security boundaries. Block on correctness bugs and on failures reachable under normal use. Do not require defenses against an actor who could already subvert the system directly, for example by editing its files; a failure that needs such an actor is not reachable.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+This is the first reviewer round for this scope.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+
+## Inlined commit-range diff from Neal (base000..head000)
+
+You have read-only repository tools (read and search, no shell) but no commit-range diff tool, so Neal has inlined the commit-range diff below.
+This inlined diff is the source of truth for exactly what this range changed, including deletions and renames that head-state file reads cannot reveal. Use your read tools to verify the surrounding code.
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-old
++new
+
+=== buildReviewerPrompt#accessMode=read-only-inlined#earlierScopeChanges=absent#previousHead=absent#reviewLevel=strict ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+The commit-range diff for that commit range is inlined below and is the source of truth for exactly what the commit range changed (including deletions and renames). Use your read tools to verify the surrounding code; you have no commit-range diff tool, so rely on the inlined diff for what changed.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Inspect the change using the inlined commit-range diff below for what changed (including deletions and renames), then read the changed files in full with your read tools and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: strict. Assume adversarial trust boundaries: treat every input, file, and process the change can be reached from, including local processes and internal run artifacts, as a potential attacker. A hardening gap or a missing defense against a local or adversarial actor is a reachable failure under these boundaries and blocks.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+This is the first reviewer round for this scope.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+
+## Inlined commit-range diff from Neal (base000..head000)
+
+You have read-only repository tools (read and search, no shell) but no commit-range diff tool, so Neal has inlined the commit-range diff below.
+This inlined diff is the source of truth for exactly what this range changed, including deletions and renames that head-state file reads cannot reveal. Use your read tools to verify the surrounding code.
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-old
++new
+
+=== buildReviewerPrompt#accessMode=read-only-inlined#earlierScopeChanges=absent#previousHead=present#reviewLevel=lenient ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+The commit-range diff for that commit range is inlined below and is the source of truth for exactly what the commit range changed (including deletions and renames). Use your read tools to verify the surrounding code; you have no commit-range diff tool, so rely on the inlined diff for what changed.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Inspect the change using the inlined commit-range diff below for what changed (including deletions and renames), then read the changed files in full with your read tools and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: lenient. Assume ordinary trust boundaries and block only on correctness failures and real, reachable bugs. Do not demand additional robustness, hardening, performance, or style work as a condition of acceptance.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Robustness or performance regressions introduced by the implementation are non_blocking unless they are a reachable correctness failure; use blocking severity only in that case.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Previous reviewer head was prevhead000. Focus especially on changes since that commit, while still considering the full current state.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+
+## Inlined commit-range diff from Neal (base000..head000)
+
+You have read-only repository tools (read and search, no shell) but no commit-range diff tool, so Neal has inlined the commit-range diff below.
+This inlined diff is the source of truth for exactly what this range changed, including deletions and renames that head-state file reads cannot reveal. Use your read tools to verify the surrounding code.
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-old
++new
+
+=== buildReviewerPrompt#accessMode=read-only-inlined#earlierScopeChanges=absent#previousHead=present#reviewLevel=moderate ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+The commit-range diff for that commit range is inlined below and is the source of truth for exactly what the commit range changed (including deletions and renames). Use your read tools to verify the surrounding code; you have no commit-range diff tool, so rely on the inlined diff for what changed.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Inspect the change using the inlined commit-range diff below for what changed (including deletions and renames), then read the changed files in full with your read tools and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: moderate. Assume ordinary trust boundaries: internal run artifacts and other files this system writes for itself are not security boundaries. Block on correctness bugs and on failures reachable under normal use. Do not require defenses against an actor who could already subvert the system directly, for example by editing its files; a failure that needs such an actor is not reachable.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Previous reviewer head was prevhead000. Focus especially on changes since that commit, while still considering the full current state.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+
+## Inlined commit-range diff from Neal (base000..head000)
+
+You have read-only repository tools (read and search, no shell) but no commit-range diff tool, so Neal has inlined the commit-range diff below.
+This inlined diff is the source of truth for exactly what this range changed, including deletions and renames that head-state file reads cannot reveal. Use your read tools to verify the surrounding code.
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-old
++new
+
+=== buildReviewerPrompt#accessMode=read-only-inlined#earlierScopeChanges=absent#previousHead=present#reviewLevel=strict ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+The commit-range diff for that commit range is inlined below and is the source of truth for exactly what the commit range changed (including deletions and renames). Use your read tools to verify the surrounding code; you have no commit-range diff tool, so rely on the inlined diff for what changed.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Inspect the change using the inlined commit-range diff below for what changed (including deletions and renames), then read the changed files in full with your read tools and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: strict. Assume adversarial trust boundaries: treat every input, file, and process the change can be reached from, including local processes and internal run artifacts, as a potential attacker. A hardening gap or a missing defense against a local or adversarial actor is a reachable failure under these boundaries and blocks.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Previous reviewer head was prevhead000. Focus especially on changes since that commit, while still considering the full current state.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+
+## Inlined commit-range diff from Neal (base000..head000)
+
+You have read-only repository tools (read and search, no shell) but no commit-range diff tool, so Neal has inlined the commit-range diff below.
+This inlined diff is the source of truth for exactly what this range changed, including deletions and renames that head-state file reads cannot reveal. Use your read tools to verify the surrounding code.
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-old
++new
+
+=== buildReviewerPrompt#accessMode=read-only-inlined#earlierScopeChanges=present#previousHead=absent#reviewLevel=lenient ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+The commit-range diff for that commit range is inlined below and is the source of truth for exactly what the commit range changed (including deletions and renames). Use your read tools to verify the surrounding code; you have no commit-range diff tool, so rely on the inlined diff for what changed.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Inspect the change using the inlined commit-range diff below for what changed (including deletions and renames), then read the changed files in full with your read tools and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: lenient. Assume ordinary trust boundaries and block only on correctness failures and real, reachable bugs. Do not demand additional robustness, hardening, performance, or style work as a condition of acceptance.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Robustness or performance regressions introduced by the implementation are non_blocking unless they are a reachable correctness failure; use blocking severity only in that case.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+This is the first reviewer round for this scope.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+
+## Inlined commit-range diff from Neal (base000..head000)
+
+You have read-only repository tools (read and search, no shell) but no commit-range diff tool, so Neal has inlined the commit-range diff below.
+This inlined diff is the source of truth for exactly what this range changed, including deletions and renames that head-state file reads cannot reveal. Use your read tools to verify the surrounding code.
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-old
++new
+
+
+## Earlier-scope changes to files in this diff
+
+The files below were changed by an earlier accepted scope in this run and appear again in the current diff. Each entry shows what that earlier scope did to the file, so what the current scope alters is something you read here rather than something you have to remember.
+Check the current diff against each entry before accepting.
+
+### src/example.ts (scope 3, scope3base000..scope3final000)
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-older
++old
+
+=== buildReviewerPrompt#accessMode=read-only-inlined#earlierScopeChanges=present#previousHead=absent#reviewLevel=moderate ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+The commit-range diff for that commit range is inlined below and is the source of truth for exactly what the commit range changed (including deletions and renames). Use your read tools to verify the surrounding code; you have no commit-range diff tool, so rely on the inlined diff for what changed.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Inspect the change using the inlined commit-range diff below for what changed (including deletions and renames), then read the changed files in full with your read tools and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: moderate. Assume ordinary trust boundaries: internal run artifacts and other files this system writes for itself are not security boundaries. Block on correctness bugs and on failures reachable under normal use. Do not require defenses against an actor who could already subvert the system directly, for example by editing its files; a failure that needs such an actor is not reachable.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+This is the first reviewer round for this scope.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+
+## Inlined commit-range diff from Neal (base000..head000)
+
+You have read-only repository tools (read and search, no shell) but no commit-range diff tool, so Neal has inlined the commit-range diff below.
+This inlined diff is the source of truth for exactly what this range changed, including deletions and renames that head-state file reads cannot reveal. Use your read tools to verify the surrounding code.
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-old
++new
+
+
+## Earlier-scope changes to files in this diff
+
+The files below were changed by an earlier accepted scope in this run and appear again in the current diff. Each entry shows what that earlier scope did to the file, so what the current scope alters is something you read here rather than something you have to remember.
+Check the current diff against each entry before accepting.
+
+### src/example.ts (scope 3, scope3base000..scope3final000)
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-older
++old
+
+=== buildReviewerPrompt#accessMode=read-only-inlined#earlierScopeChanges=present#previousHead=absent#reviewLevel=strict ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+The commit-range diff for that commit range is inlined below and is the source of truth for exactly what the commit range changed (including deletions and renames). Use your read tools to verify the surrounding code; you have no commit-range diff tool, so rely on the inlined diff for what changed.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Inspect the change using the inlined commit-range diff below for what changed (including deletions and renames), then read the changed files in full with your read tools and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: strict. Assume adversarial trust boundaries: treat every input, file, and process the change can be reached from, including local processes and internal run artifacts, as a potential attacker. A hardening gap or a missing defense against a local or adversarial actor is a reachable failure under these boundaries and blocks.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+This is the first reviewer round for this scope.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+
+## Inlined commit-range diff from Neal (base000..head000)
+
+You have read-only repository tools (read and search, no shell) but no commit-range diff tool, so Neal has inlined the commit-range diff below.
+This inlined diff is the source of truth for exactly what this range changed, including deletions and renames that head-state file reads cannot reveal. Use your read tools to verify the surrounding code.
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-old
++new
+
+
+## Earlier-scope changes to files in this diff
+
+The files below were changed by an earlier accepted scope in this run and appear again in the current diff. Each entry shows what that earlier scope did to the file, so what the current scope alters is something you read here rather than something you have to remember.
+Check the current diff against each entry before accepting.
+
+### src/example.ts (scope 3, scope3base000..scope3final000)
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-older
++old
+
+=== buildReviewerPrompt#accessMode=read-only-inlined#earlierScopeChanges=present#previousHead=present#reviewLevel=lenient ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+The commit-range diff for that commit range is inlined below and is the source of truth for exactly what the commit range changed (including deletions and renames). Use your read tools to verify the surrounding code; you have no commit-range diff tool, so rely on the inlined diff for what changed.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Inspect the change using the inlined commit-range diff below for what changed (including deletions and renames), then read the changed files in full with your read tools and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: lenient. Assume ordinary trust boundaries and block only on correctness failures and real, reachable bugs. Do not demand additional robustness, hardening, performance, or style work as a condition of acceptance.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Robustness or performance regressions introduced by the implementation are non_blocking unless they are a reachable correctness failure; use blocking severity only in that case.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Previous reviewer head was prevhead000. Focus especially on changes since that commit, while still considering the full current state.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+
+## Inlined commit-range diff from Neal (base000..head000)
+
+You have read-only repository tools (read and search, no shell) but no commit-range diff tool, so Neal has inlined the commit-range diff below.
+This inlined diff is the source of truth for exactly what this range changed, including deletions and renames that head-state file reads cannot reveal. Use your read tools to verify the surrounding code.
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-old
++new
+
+
+## Earlier-scope changes to files in this diff
+
+The files below were changed by an earlier accepted scope in this run and appear again in the current diff. Each entry shows what that earlier scope did to the file, so what the current scope alters is something you read here rather than something you have to remember.
+Check the current diff against each entry before accepting.
+
+### src/example.ts (scope 3, scope3base000..scope3final000)
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-older
++old
+
+=== buildReviewerPrompt#accessMode=read-only-inlined#earlierScopeChanges=present#previousHead=present#reviewLevel=moderate ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+The commit-range diff for that commit range is inlined below and is the source of truth for exactly what the commit range changed (including deletions and renames). Use your read tools to verify the surrounding code; you have no commit-range diff tool, so rely on the inlined diff for what changed.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Inspect the change using the inlined commit-range diff below for what changed (including deletions and renames), then read the changed files in full with your read tools and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: moderate. Assume ordinary trust boundaries: internal run artifacts and other files this system writes for itself are not security boundaries. Block on correctness bugs and on failures reachable under normal use. Do not require defenses against an actor who could already subvert the system directly, for example by editing its files; a failure that needs such an actor is not reachable.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Previous reviewer head was prevhead000. Focus especially on changes since that commit, while still considering the full current state.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+
+## Inlined commit-range diff from Neal (base000..head000)
+
+You have read-only repository tools (read and search, no shell) but no commit-range diff tool, so Neal has inlined the commit-range diff below.
+This inlined diff is the source of truth for exactly what this range changed, including deletions and renames that head-state file reads cannot reveal. Use your read tools to verify the surrounding code.
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-old
++new
+
+
+## Earlier-scope changes to files in this diff
+
+The files below were changed by an earlier accepted scope in this run and appear again in the current diff. Each entry shows what that earlier scope did to the file, so what the current scope alters is something you read here rather than something you have to remember.
+Check the current diff against each entry before accepting.
+
+### src/example.ts (scope 3, scope3base000..scope3final000)
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-older
++old
+
+=== buildReviewerPrompt#accessMode=read-only-inlined#earlierScopeChanges=present#previousHead=present#reviewLevel=strict ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+The commit-range diff for that commit range is inlined below and is the source of truth for exactly what the commit range changed (including deletions and renames). Use your read tools to verify the surrounding code; you have no commit-range diff tool, so rely on the inlined diff for what changed.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Inspect the change using the inlined commit-range diff below for what changed (including deletions and renames), then read the changed files in full with your read tools and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: strict. Assume adversarial trust boundaries: treat every input, file, and process the change can be reached from, including local processes and internal run artifacts, as a potential attacker. A hardening gap or a missing defense against a local or adversarial actor is a reachable failure under these boundaries and blocks.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Previous reviewer head was prevhead000. Focus especially on changes since that commit, while still considering the full current state.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+
+## Inlined commit-range diff from Neal (base000..head000)
+
+You have read-only repository tools (read and search, no shell) but no commit-range diff tool, so Neal has inlined the commit-range diff below.
+This inlined diff is the source of truth for exactly what this range changed, including deletions and renames that head-state file reads cannot reveal. Use your read tools to verify the surrounding code.
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-old
++new
+
+
+## Earlier-scope changes to files in this diff
+
+The files below were changed by an earlier accepted scope in this run and appear again in the current diff. Each entry shows what that earlier scope did to the file, so what the current scope alters is something you read here rather than something you have to remember.
+Check the current diff against each entry before accepting.
+
+### src/example.ts (scope 3, scope3base000..scope3final000)
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-older
++old
+
+=== buildReviewerPrompt#accessMode=read-only-tool#earlierScopeChanges=absent#previousHead=absent#reviewLevel=lenient ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+Review that commit range directly with your read-only repository tools: use the git_diff tool to see exactly what the commit range changed (including deletions and renames), and your read tools to verify the surrounding code. The commit range is the source of truth for this review.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Inspect the change with your read-only tools: call git_diff with the base and head commits named in this prompt (stat:true first for the changed-file overview, then per-path diffs), read the changed files in full, and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: lenient. Assume ordinary trust boundaries and block only on correctness failures and real, reachable bugs. Do not demand additional robustness, hardening, performance, or style work as a condition of acceptance.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Robustness or performance regressions introduced by the implementation are non_blocking unless they are a reachable correctness failure; use blocking severity only in that case.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+This is the first reviewer round for this scope.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+=== buildReviewerPrompt#accessMode=read-only-tool#earlierScopeChanges=absent#previousHead=absent#reviewLevel=moderate ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+Review that commit range directly with your read-only repository tools: use the git_diff tool to see exactly what the commit range changed (including deletions and renames), and your read tools to verify the surrounding code. The commit range is the source of truth for this review.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Inspect the change with your read-only tools: call git_diff with the base and head commits named in this prompt (stat:true first for the changed-file overview, then per-path diffs), read the changed files in full, and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: moderate. Assume ordinary trust boundaries: internal run artifacts and other files this system writes for itself are not security boundaries. Block on correctness bugs and on failures reachable under normal use. Do not require defenses against an actor who could already subvert the system directly, for example by editing its files; a failure that needs such an actor is not reachable.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+This is the first reviewer round for this scope.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+=== buildReviewerPrompt#accessMode=read-only-tool#earlierScopeChanges=absent#previousHead=absent#reviewLevel=strict ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+Review that commit range directly with your read-only repository tools: use the git_diff tool to see exactly what the commit range changed (including deletions and renames), and your read tools to verify the surrounding code. The commit range is the source of truth for this review.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Inspect the change with your read-only tools: call git_diff with the base and head commits named in this prompt (stat:true first for the changed-file overview, then per-path diffs), read the changed files in full, and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: strict. Assume adversarial trust boundaries: treat every input, file, and process the change can be reached from, including local processes and internal run artifacts, as a potential attacker. A hardening gap or a missing defense against a local or adversarial actor is a reachable failure under these boundaries and blocks.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+This is the first reviewer round for this scope.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+=== buildReviewerPrompt#accessMode=read-only-tool#earlierScopeChanges=absent#previousHead=present#reviewLevel=lenient ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+Review that commit range directly with your read-only repository tools: use the git_diff tool to see exactly what the commit range changed (including deletions and renames), and your read tools to verify the surrounding code. The commit range is the source of truth for this review.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Inspect the change with your read-only tools: call git_diff with the base and head commits named in this prompt (stat:true first for the changed-file overview, then per-path diffs), read the changed files in full, and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: lenient. Assume ordinary trust boundaries and block only on correctness failures and real, reachable bugs. Do not demand additional robustness, hardening, performance, or style work as a condition of acceptance.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Robustness or performance regressions introduced by the implementation are non_blocking unless they are a reachable correctness failure; use blocking severity only in that case.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Previous reviewer head was prevhead000. Focus especially on changes since that commit, while still considering the full current state.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+=== buildReviewerPrompt#accessMode=read-only-tool#earlierScopeChanges=absent#previousHead=present#reviewLevel=moderate ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+Review that commit range directly with your read-only repository tools: use the git_diff tool to see exactly what the commit range changed (including deletions and renames), and your read tools to verify the surrounding code. The commit range is the source of truth for this review.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Inspect the change with your read-only tools: call git_diff with the base and head commits named in this prompt (stat:true first for the changed-file overview, then per-path diffs), read the changed files in full, and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: moderate. Assume ordinary trust boundaries: internal run artifacts and other files this system writes for itself are not security boundaries. Block on correctness bugs and on failures reachable under normal use. Do not require defenses against an actor who could already subvert the system directly, for example by editing its files; a failure that needs such an actor is not reachable.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Previous reviewer head was prevhead000. Focus especially on changes since that commit, while still considering the full current state.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+=== buildReviewerPrompt#accessMode=read-only-tool#earlierScopeChanges=absent#previousHead=present#reviewLevel=strict ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+Review that commit range directly with your read-only repository tools: use the git_diff tool to see exactly what the commit range changed (including deletions and renames), and your read tools to verify the surrounding code. The commit range is the source of truth for this review.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Inspect the change with your read-only tools: call git_diff with the base and head commits named in this prompt (stat:true first for the changed-file overview, then per-path diffs), read the changed files in full, and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: strict. Assume adversarial trust boundaries: treat every input, file, and process the change can be reached from, including local processes and internal run artifacts, as a potential attacker. A hardening gap or a missing defense against a local or adversarial actor is a reachable failure under these boundaries and blocks.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Previous reviewer head was prevhead000. Focus especially on changes since that commit, while still considering the full current state.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+=== buildReviewerPrompt#accessMode=read-only-tool#earlierScopeChanges=present#previousHead=absent#reviewLevel=lenient ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+Review that commit range directly with your read-only repository tools: use the git_diff tool to see exactly what the commit range changed (including deletions and renames), and your read tools to verify the surrounding code. The commit range is the source of truth for this review.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Inspect the change with your read-only tools: call git_diff with the base and head commits named in this prompt (stat:true first for the changed-file overview, then per-path diffs), read the changed files in full, and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: lenient. Assume ordinary trust boundaries and block only on correctness failures and real, reachable bugs. Do not demand additional robustness, hardening, performance, or style work as a condition of acceptance.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Robustness or performance regressions introduced by the implementation are non_blocking unless they are a reachable correctness failure; use blocking severity only in that case.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+This is the first reviewer round for this scope.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+
+## Earlier-scope changes to files in this diff
+
+The files below were changed by an earlier accepted scope in this run and appear again in the current diff. Each entry shows what that earlier scope did to the file, so what the current scope alters is something you read here rather than something you have to remember.
+Check the current diff against each entry before accepting.
+
+### src/example.ts (scope 3, scope3base000..scope3final000)
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-older
++old
+
+=== buildReviewerPrompt#accessMode=read-only-tool#earlierScopeChanges=present#previousHead=absent#reviewLevel=moderate ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+Review that commit range directly with your read-only repository tools: use the git_diff tool to see exactly what the commit range changed (including deletions and renames), and your read tools to verify the surrounding code. The commit range is the source of truth for this review.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Inspect the change with your read-only tools: call git_diff with the base and head commits named in this prompt (stat:true first for the changed-file overview, then per-path diffs), read the changed files in full, and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: moderate. Assume ordinary trust boundaries: internal run artifacts and other files this system writes for itself are not security boundaries. Block on correctness bugs and on failures reachable under normal use. Do not require defenses against an actor who could already subvert the system directly, for example by editing its files; a failure that needs such an actor is not reachable.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+This is the first reviewer round for this scope.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+
+## Earlier-scope changes to files in this diff
+
+The files below were changed by an earlier accepted scope in this run and appear again in the current diff. Each entry shows what that earlier scope did to the file, so what the current scope alters is something you read here rather than something you have to remember.
+Check the current diff against each entry before accepting.
+
+### src/example.ts (scope 3, scope3base000..scope3final000)
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-older
++old
+
+=== buildReviewerPrompt#accessMode=read-only-tool#earlierScopeChanges=present#previousHead=absent#reviewLevel=strict ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+Review that commit range directly with your read-only repository tools: use the git_diff tool to see exactly what the commit range changed (including deletions and renames), and your read tools to verify the surrounding code. The commit range is the source of truth for this review.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Inspect the change with your read-only tools: call git_diff with the base and head commits named in this prompt (stat:true first for the changed-file overview, then per-path diffs), read the changed files in full, and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: strict. Assume adversarial trust boundaries: treat every input, file, and process the change can be reached from, including local processes and internal run artifacts, as a potential attacker. A hardening gap or a missing defense against a local or adversarial actor is a reachable failure under these boundaries and blocks.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+This is the first reviewer round for this scope.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+
+## Earlier-scope changes to files in this diff
+
+The files below were changed by an earlier accepted scope in this run and appear again in the current diff. Each entry shows what that earlier scope did to the file, so what the current scope alters is something you read here rather than something you have to remember.
+Check the current diff against each entry before accepting.
+
+### src/example.ts (scope 3, scope3base000..scope3final000)
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-older
++old
+
+=== buildReviewerPrompt#accessMode=read-only-tool#earlierScopeChanges=present#previousHead=present#reviewLevel=lenient ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+Review that commit range directly with your read-only repository tools: use the git_diff tool to see exactly what the commit range changed (including deletions and renames), and your read tools to verify the surrounding code. The commit range is the source of truth for this review.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Inspect the change with your read-only tools: call git_diff with the base and head commits named in this prompt (stat:true first for the changed-file overview, then per-path diffs), read the changed files in full, and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: lenient. Assume ordinary trust boundaries and block only on correctness failures and real, reachable bugs. Do not demand additional robustness, hardening, performance, or style work as a condition of acceptance.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Robustness or performance regressions introduced by the implementation are non_blocking unless they are a reachable correctness failure; use blocking severity only in that case.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Previous reviewer head was prevhead000. Focus especially on changes since that commit, while still considering the full current state.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+
+## Earlier-scope changes to files in this diff
+
+The files below were changed by an earlier accepted scope in this run and appear again in the current diff. Each entry shows what that earlier scope did to the file, so what the current scope alters is something you read here rather than something you have to remember.
+Check the current diff against each entry before accepting.
+
+### src/example.ts (scope 3, scope3base000..scope3final000)
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-older
++old
+
+=== buildReviewerPrompt#accessMode=read-only-tool#earlierScopeChanges=present#previousHead=present#reviewLevel=moderate ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+Review that commit range directly with your read-only repository tools: use the git_diff tool to see exactly what the commit range changed (including deletions and renames), and your read tools to verify the surrounding code. The commit range is the source of truth for this review.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Inspect the change with your read-only tools: call git_diff with the base and head commits named in this prompt (stat:true first for the changed-file overview, then per-path diffs), read the changed files in full, and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: moderate. Assume ordinary trust boundaries: internal run artifacts and other files this system writes for itself are not security boundaries. Block on correctness bugs and on failures reachable under normal use. Do not require defenses against an actor who could already subvert the system directly, for example by editing its files; a failure that needs such an actor is not reachable.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Previous reviewer head was prevhead000. Focus especially on changes since that commit, while still considering the full current state.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+
+## Earlier-scope changes to files in this diff
+
+The files below were changed by an earlier accepted scope in this run and appear again in the current diff. Each entry shows what that earlier scope did to the file, so what the current scope alters is something you read here rather than something you have to remember.
+Check the current diff against each entry before accepting.
+
+### src/example.ts (scope 3, scope3base000..scope3final000)
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-older
++old
+
+=== buildReviewerPrompt#accessMode=read-only-tool#earlierScopeChanges=present#previousHead=present#reviewLevel=strict ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+Review that commit range directly with your read-only repository tools: use the git_diff tool to see exactly what the commit range changed (including deletions and renames), and your read tools to verify the surrounding code. The commit range is the source of truth for this review.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Inspect the change with your read-only tools: call git_diff with the base and head commits named in this prompt (stat:true first for the changed-file overview, then per-path diffs), read the changed files in full, and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: strict. Assume adversarial trust boundaries: treat every input, file, and process the change can be reached from, including local processes and internal run artifacts, as a potential attacker. A hardening gap or a missing defense against a local or adversarial actor is a reachable failure under these boundaries and blocks.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Previous reviewer head was prevhead000. Focus especially on changes since that commit, while still considering the full current state.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+
+## Earlier-scope changes to files in this diff
+
+The files below were changed by an earlier accepted scope in this run and appear again in the current diff. Each entry shows what that earlier scope did to the file, so what the current scope alters is something you read here rather than something you have to remember.
+Check the current diff against each entry before accepting.
+
+### src/example.ts (scope 3, scope3base000..scope3final000)
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-older
++old
+
+=== buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=absent#previousHead=absent#reviewLevel=lenient ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+Review that commit range directly with repository tools. The commit range is the source of truth for this review.
+Use git commands against the repository, for example: git diff base000..head000, git show --stat head000, and targeted path diffs or file reads for changed files.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Temporary verification scratch directory: /tmp/repo/.neal/runs/run-000/scratch/review
+Use that run-local scratch directory for temporary verification artifacts, copied tests, scratch builds, logs, and modified throwaway files.
+Do not create project-root scratch directories such as build_review/.
+Do not leave project-tree scratch files behind; keep scratch work under the run-local directory above.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: lenient. Assume ordinary trust boundaries and block only on correctness failures and real, reachable bugs. Do not demand additional robustness, hardening, performance, or style work as a condition of acceptance.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Robustness or performance regressions introduced by the implementation are non_blocking unless they are a reachable correctness failure; use blocking severity only in that case.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — running them when available — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, exercise or reason through the affected existing flows directly — run the most relevant existing tests or reproduce the reported behavior when practical — rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+This is the first reviewer round for this scope.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+=== buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=absent#previousHead=absent#reviewLevel=moderate ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+Review that commit range directly with repository tools. The commit range is the source of truth for this review.
+Use git commands against the repository, for example: git diff base000..head000, git show --stat head000, and targeted path diffs or file reads for changed files.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Temporary verification scratch directory: /tmp/repo/.neal/runs/run-000/scratch/review
+Use that run-local scratch directory for temporary verification artifacts, copied tests, scratch builds, logs, and modified throwaway files.
+Do not create project-root scratch directories such as build_review/.
+Do not leave project-tree scratch files behind; keep scratch work under the run-local directory above.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: moderate. Assume ordinary trust boundaries: internal run artifacts and other files this system writes for itself are not security boundaries. Block on correctness bugs and on failures reachable under normal use. Do not require defenses against an actor who could already subvert the system directly, for example by editing its files; a failure that needs such an actor is not reachable.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — running them when available — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, exercise or reason through the affected existing flows directly — run the most relevant existing tests or reproduce the reported behavior when practical — rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+This is the first reviewer round for this scope.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+=== buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=absent#previousHead=absent#reviewLevel=strict ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+Review that commit range directly with repository tools. The commit range is the source of truth for this review.
+Use git commands against the repository, for example: git diff base000..head000, git show --stat head000, and targeted path diffs or file reads for changed files.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Temporary verification scratch directory: /tmp/repo/.neal/runs/run-000/scratch/review
+Use that run-local scratch directory for temporary verification artifacts, copied tests, scratch builds, logs, and modified throwaway files.
+Do not create project-root scratch directories such as build_review/.
+Do not leave project-tree scratch files behind; keep scratch work under the run-local directory above.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: strict. Assume adversarial trust boundaries: treat every input, file, and process the change can be reached from, including local processes and internal run artifacts, as a potential attacker. A hardening gap or a missing defense against a local or adversarial actor is a reachable failure under these boundaries and blocks.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — running them when available — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, exercise or reason through the affected existing flows directly — run the most relevant existing tests or reproduce the reported behavior when practical — rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+This is the first reviewer round for this scope.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+=== buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=absent#previousHead=present#reviewLevel=lenient ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+Review that commit range directly with repository tools. The commit range is the source of truth for this review.
+Use git commands against the repository, for example: git diff base000..head000, git show --stat head000, and targeted path diffs or file reads for changed files.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Temporary verification scratch directory: /tmp/repo/.neal/runs/run-000/scratch/review
+Use that run-local scratch directory for temporary verification artifacts, copied tests, scratch builds, logs, and modified throwaway files.
+Do not create project-root scratch directories such as build_review/.
+Do not leave project-tree scratch files behind; keep scratch work under the run-local directory above.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: lenient. Assume ordinary trust boundaries and block only on correctness failures and real, reachable bugs. Do not demand additional robustness, hardening, performance, or style work as a condition of acceptance.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Robustness or performance regressions introduced by the implementation are non_blocking unless they are a reachable correctness failure; use blocking severity only in that case.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — running them when available — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, exercise or reason through the affected existing flows directly — run the most relevant existing tests or reproduce the reported behavior when practical — rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Previous reviewer head was prevhead000. Focus especially on changes since that commit, while still considering the full current state.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+=== buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=absent#previousHead=present#reviewLevel=moderate ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+Review that commit range directly with repository tools. The commit range is the source of truth for this review.
+Use git commands against the repository, for example: git diff base000..head000, git show --stat head000, and targeted path diffs or file reads for changed files.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Temporary verification scratch directory: /tmp/repo/.neal/runs/run-000/scratch/review
+Use that run-local scratch directory for temporary verification artifacts, copied tests, scratch builds, logs, and modified throwaway files.
+Do not create project-root scratch directories such as build_review/.
+Do not leave project-tree scratch files behind; keep scratch work under the run-local directory above.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: moderate. Assume ordinary trust boundaries: internal run artifacts and other files this system writes for itself are not security boundaries. Block on correctness bugs and on failures reachable under normal use. Do not require defenses against an actor who could already subvert the system directly, for example by editing its files; a failure that needs such an actor is not reachable.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — running them when available — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, exercise or reason through the affected existing flows directly — run the most relevant existing tests or reproduce the reported behavior when practical — rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Previous reviewer head was prevhead000. Focus especially on changes since that commit, while still considering the full current state.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+=== buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=absent#previousHead=present#reviewLevel=strict ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+Review that commit range directly with repository tools. The commit range is the source of truth for this review.
+Use git commands against the repository, for example: git diff base000..head000, git show --stat head000, and targeted path diffs or file reads for changed files.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Temporary verification scratch directory: /tmp/repo/.neal/runs/run-000/scratch/review
+Use that run-local scratch directory for temporary verification artifacts, copied tests, scratch builds, logs, and modified throwaway files.
+Do not create project-root scratch directories such as build_review/.
+Do not leave project-tree scratch files behind; keep scratch work under the run-local directory above.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: strict. Assume adversarial trust boundaries: treat every input, file, and process the change can be reached from, including local processes and internal run artifacts, as a potential attacker. A hardening gap or a missing defense against a local or adversarial actor is a reachable failure under these boundaries and blocks.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — running them when available — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, exercise or reason through the affected existing flows directly — run the most relevant existing tests or reproduce the reported behavior when practical — rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Previous reviewer head was prevhead000. Focus especially on changes since that commit, while still considering the full current state.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+=== buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=present#previousHead=absent#reviewLevel=lenient ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+Review that commit range directly with repository tools. The commit range is the source of truth for this review.
+Use git commands against the repository, for example: git diff base000..head000, git show --stat head000, and targeted path diffs or file reads for changed files.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Temporary verification scratch directory: /tmp/repo/.neal/runs/run-000/scratch/review
+Use that run-local scratch directory for temporary verification artifacts, copied tests, scratch builds, logs, and modified throwaway files.
+Do not create project-root scratch directories such as build_review/.
+Do not leave project-tree scratch files behind; keep scratch work under the run-local directory above.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: lenient. Assume ordinary trust boundaries and block only on correctness failures and real, reachable bugs. Do not demand additional robustness, hardening, performance, or style work as a condition of acceptance.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Robustness or performance regressions introduced by the implementation are non_blocking unless they are a reachable correctness failure; use blocking severity only in that case.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — running them when available — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, exercise or reason through the affected existing flows directly — run the most relevant existing tests or reproduce the reported behavior when practical — rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+This is the first reviewer round for this scope.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+
+## Earlier-scope changes to files in this diff
+
+The files below were changed by an earlier accepted scope in this run and appear again in the current diff. Each entry shows what that earlier scope did to the file, so what the current scope alters is something you read here rather than something you have to remember.
+Check the current diff against each entry before accepting.
+
+### src/example.ts (scope 3, scope3base000..scope3final000)
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-older
++old
+
+=== buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=present#previousHead=absent#reviewLevel=moderate ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+Review that commit range directly with repository tools. The commit range is the source of truth for this review.
+Use git commands against the repository, for example: git diff base000..head000, git show --stat head000, and targeted path diffs or file reads for changed files.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Temporary verification scratch directory: /tmp/repo/.neal/runs/run-000/scratch/review
+Use that run-local scratch directory for temporary verification artifacts, copied tests, scratch builds, logs, and modified throwaway files.
+Do not create project-root scratch directories such as build_review/.
+Do not leave project-tree scratch files behind; keep scratch work under the run-local directory above.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: moderate. Assume ordinary trust boundaries: internal run artifacts and other files this system writes for itself are not security boundaries. Block on correctness bugs and on failures reachable under normal use. Do not require defenses against an actor who could already subvert the system directly, for example by editing its files; a failure that needs such an actor is not reachable.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — running them when available — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, exercise or reason through the affected existing flows directly — run the most relevant existing tests or reproduce the reported behavior when practical — rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+This is the first reviewer round for this scope.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+
+## Earlier-scope changes to files in this diff
+
+The files below were changed by an earlier accepted scope in this run and appear again in the current diff. Each entry shows what that earlier scope did to the file, so what the current scope alters is something you read here rather than something you have to remember.
+Check the current diff against each entry before accepting.
+
+### src/example.ts (scope 3, scope3base000..scope3final000)
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-older
++old
+
+=== buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=present#previousHead=absent#reviewLevel=strict ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+Review that commit range directly with repository tools. The commit range is the source of truth for this review.
+Use git commands against the repository, for example: git diff base000..head000, git show --stat head000, and targeted path diffs or file reads for changed files.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Temporary verification scratch directory: /tmp/repo/.neal/runs/run-000/scratch/review
+Use that run-local scratch directory for temporary verification artifacts, copied tests, scratch builds, logs, and modified throwaway files.
+Do not create project-root scratch directories such as build_review/.
+Do not leave project-tree scratch files behind; keep scratch work under the run-local directory above.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: strict. Assume adversarial trust boundaries: treat every input, file, and process the change can be reached from, including local processes and internal run artifacts, as a potential attacker. A hardening gap or a missing defense against a local or adversarial actor is a reachable failure under these boundaries and blocks.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — running them when available — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, exercise or reason through the affected existing flows directly — run the most relevant existing tests or reproduce the reported behavior when practical — rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+This is the first reviewer round for this scope.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+
+## Earlier-scope changes to files in this diff
+
+The files below were changed by an earlier accepted scope in this run and appear again in the current diff. Each entry shows what that earlier scope did to the file, so what the current scope alters is something you read here rather than something you have to remember.
+Check the current diff against each entry before accepting.
+
+### src/example.ts (scope 3, scope3base000..scope3final000)
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-older
++old
+
+=== buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=present#previousHead=present#reviewLevel=lenient ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+Review that commit range directly with repository tools. The commit range is the source of truth for this review.
+Use git commands against the repository, for example: git diff base000..head000, git show --stat head000, and targeted path diffs or file reads for changed files.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Temporary verification scratch directory: /tmp/repo/.neal/runs/run-000/scratch/review
+Use that run-local scratch directory for temporary verification artifacts, copied tests, scratch builds, logs, and modified throwaway files.
+Do not create project-root scratch directories such as build_review/.
+Do not leave project-tree scratch files behind; keep scratch work under the run-local directory above.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: lenient. Assume ordinary trust boundaries and block only on correctness failures and real, reachable bugs. Do not demand additional robustness, hardening, performance, or style work as a condition of acceptance.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Robustness or performance regressions introduced by the implementation are non_blocking unless they are a reachable correctness failure; use blocking severity only in that case.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — running them when available — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, exercise or reason through the affected existing flows directly — run the most relevant existing tests or reproduce the reported behavior when practical — rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Previous reviewer head was prevhead000. Focus especially on changes since that commit, while still considering the full current state.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+
+## Earlier-scope changes to files in this diff
+
+The files below were changed by an earlier accepted scope in this run and appear again in the current diff. Each entry shows what that earlier scope did to the file, so what the current scope alters is something you read here rather than something you have to remember.
+Check the current diff against each entry before accepting.
+
+### src/example.ts (scope 3, scope3base000..scope3final000)
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-older
++old
+
+=== buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=present#previousHead=present#reviewLevel=moderate ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+Review that commit range directly with repository tools. The commit range is the source of truth for this review.
+Use git commands against the repository, for example: git diff base000..head000, git show --stat head000, and targeted path diffs or file reads for changed files.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Temporary verification scratch directory: /tmp/repo/.neal/runs/run-000/scratch/review
+Use that run-local scratch directory for temporary verification artifacts, copied tests, scratch builds, logs, and modified throwaway files.
+Do not create project-root scratch directories such as build_review/.
+Do not leave project-tree scratch files behind; keep scratch work under the run-local directory above.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: moderate. Assume ordinary trust boundaries: internal run artifacts and other files this system writes for itself are not security boundaries. Block on correctness bugs and on failures reachable under normal use. Do not require defenses against an actor who could already subvert the system directly, for example by editing its files; a failure that needs such an actor is not reachable.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — running them when available — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, exercise or reason through the affected existing flows directly — run the most relevant existing tests or reproduce the reported behavior when practical — rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Previous reviewer head was prevhead000. Focus especially on changes since that commit, while still considering the full current state.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+
+## Earlier-scope changes to files in this diff
+
+The files below were changed by an earlier accepted scope in this run and appear again in the current diff. Each entry shows what that earlier scope did to the file, so what the current scope alters is something you read here rather than something you have to remember.
+Check the current diff against each entry before accepting.
+
+### src/example.ts (scope 3, scope3base000..scope3final000)
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-older
++old
+
+=== buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=present#previousHead=present#reviewLevel=strict ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+Review that commit range directly with repository tools. The commit range is the source of truth for this review.
+Use git commands against the repository, for example: git diff base000..head000, git show --stat head000, and targeted path diffs or file reads for changed files.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Temporary verification scratch directory: /tmp/repo/.neal/runs/run-000/scratch/review
+Use that run-local scratch directory for temporary verification artifacts, copied tests, scratch builds, logs, and modified throwaway files.
+Do not create project-root scratch directories such as build_review/.
+Do not leave project-tree scratch files behind; keep scratch work under the run-local directory above.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: strict. Assume adversarial trust boundaries: treat every input, file, and process the change can be reached from, including local processes and internal run artifacts, as a potential attacker. A hardening gap or a missing defense against a local or adversarial actor is a reachable failure under these boundaries and blocks.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — running them when available — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, exercise or reason through the affected existing flows directly — run the most relevant existing tests or reproduce the reported behavior when practical — rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Previous reviewer head was prevhead000. Focus especially on changes since that commit, while still considering the full current state.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+
+## Earlier-scope changes to files in this diff
+
+The files below were changed by an earlier accepted scope in this run and appear again in the current diff. Each entry shows what that earlier scope did to the file, so what the current scope alters is something you read here rather than something you have to remember.
+Check the current diff against each entry before accepting.
+
+### src/example.ts (scope 3, scope3base000..scope3final000)
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-older
++old
+

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,6 +1,7 @@
 import test, { mock } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFile, spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
 import { access, mkdir, mkdtemp, readFile, realpath, readdir, stat, writeFile } from 'node:fs/promises';
 import { hostname, tmpdir } from 'node:os';
 import { basename, dirname, join } from 'node:path';
@@ -1948,6 +1949,224 @@ test('neal resume continues ordinary failed coder scopes without guidance', asyn
   assert.match(persisted, /interactive_blocked_recovery/);
   const eventTypes = await readRunEventTypes(failedState.runDir);
   assert.ok(eventTypes.includes('run.resumed'));
+});
+
+test('neal resume rejects an invalid review_level before any agent turn and leaves run state untouched', async () => {
+  const { cwd, loaded } = await createRepoRunFixture('neal-resume-invalid-review-level-');
+  const failedState = await saveState(loaded.statePath, {
+    ...loaded.state,
+    phase: 'coder_scope',
+    status: 'failed',
+  });
+  const runId = basename(failedState.runDir);
+  const stateBefore = await readFile(getRunStatePath(failedState.runDir), 'utf8');
+  await writeFile(join(cwd, 'neal.yml'), 'neal:\n  review_level: paranoid\n', 'utf8');
+  clearConfigCache(cwd);
+  let promptCalls = 0;
+
+  setProviderCapabilitiesOverrideForTesting('openai-codex', {
+    createCoderAdapter() {
+      return {
+        async runPrompt() {
+          promptCalls += 1;
+          throw new Error('provider should not be called');
+        },
+        async runStructuredPrompt() {
+          promptCalls += 1;
+          throw new Error('provider should not be called');
+        },
+      };
+    },
+  });
+
+  try {
+    await assert.rejects(
+      () => withProcessCwd(cwd, () => captureProcessOutput(() => runResumeRunCommand(['resume', '--run', runId]))),
+      /Invalid review level for neal\.review_level: "paranoid"\. Valid values: strict, moderate, lenient/,
+    );
+  } finally {
+    clearProviderCapabilitiesOverridesForTesting();
+    clearConfigCache(cwd);
+  }
+
+  assert.equal(promptCalls, 0);
+  assert.equal(await readFile(getRunStatePath(failedState.runDir), 'utf8'), stateBefore);
+  const eventTypes = await readRunEventTypes(failedState.runDir);
+  assert.equal(eventTypes.includes('run.resumed'), false);
+});
+
+test('neal resume rejects an invalid review_level before running manual-gate checks', async () => {
+  const { cwd, loaded } = await createRepoRunFixture('neal-resume-manual-gate-invalid-review-level-');
+  const now = new Date().toISOString();
+  const checkMarker = join(cwd, 'gate-check-ran');
+  const manualGateState = await saveState(loaded.statePath, {
+    ...loaded.state,
+    phase: 'manual_gate',
+    status: 'running',
+    manualGate: {
+      id: 'approval',
+      title: 'Approval required',
+      reason: 'The user must approve deployment.',
+      instructionsPath: join(loaded.state.runDir, 'GATE-approval.md'),
+      resumeChecks: [
+        {
+          type: 'command',
+          name: 'approval file',
+          command: [process.execPath, '-e', `require("node:fs").writeFileSync(${JSON.stringify(checkMarker)}, "ran")`],
+        },
+      ],
+      resumePhase: 'coder_scope',
+      createdAt: now,
+      updatedAt: now,
+      lastCheckedAt: null,
+      lastFailure: null,
+    },
+  });
+  const runId = basename(manualGateState.runDir);
+  const stateBefore = await readFile(getRunStatePath(manualGateState.runDir), 'utf8');
+  const eventsBefore = await readRunEventTypes(manualGateState.runDir);
+  await writeFile(join(cwd, 'neal.yml'), 'neal:\n  review_level: paranoid\n', 'utf8');
+  clearConfigCache(cwd);
+  let promptCalls = 0;
+
+  setProviderCapabilitiesOverrideForTesting('openai-codex', {
+    createCoderAdapter() {
+      return {
+        async runPrompt() {
+          promptCalls += 1;
+          throw new Error('provider should not be called');
+        },
+        async runStructuredPrompt() {
+          promptCalls += 1;
+          throw new Error('provider should not be called');
+        },
+      };
+    },
+  });
+
+  try {
+    await assert.rejects(
+      () => withProcessCwd(cwd, () => captureProcessOutput(() => runResumeRunCommand(['resume', '--run', runId]))),
+      /Invalid review level for neal\.review_level: "paranoid"\. Valid values: strict, moderate, lenient/,
+    );
+  } finally {
+    clearProviderCapabilitiesOverridesForTesting();
+    clearConfigCache(cwd);
+  }
+
+  assert.equal(promptCalls, 0);
+  assert.equal(existsSync(checkMarker), false);
+  assert.equal(await readFile(getRunStatePath(manualGateState.runDir), 'utf8'), stateBefore);
+  assert.deepEqual(await readRunEventTypes(manualGateState.runDir), eventsBefore);
+});
+
+test('neal resume --message rejects an invalid review_level before recording guidance', async () => {
+  const { cwd, loaded } = await createRepoRunFixture('neal-resume-message-invalid-review-level-');
+  const blockedState = await saveState(loaded.statePath, {
+    ...loaded.state,
+    phase: 'interactive_blocked_recovery',
+    status: 'running',
+    blockedFromPhase: 'reviewer_scope',
+    interactiveBlockedRecovery: {
+      enteredAt: new Date().toISOString(),
+      sourcePhase: 'reviewer_scope',
+      blockedReason: 'Review findings did not converge',
+      maxTurns: 3,
+      lastHandledTurn: 0,
+      pendingDirective: null,
+      turns: [],
+    },
+  });
+  const runId = basename(blockedState.runDir);
+  const stateBefore = await readFile(getRunStatePath(blockedState.runDir), 'utf8');
+  const eventsBefore = await readRunEventTypes(blockedState.runDir);
+  await writeFile(join(cwd, 'neal.yml'), 'neal:\n  review_level: paranoid\n', 'utf8');
+  clearConfigCache(cwd);
+  let promptCalls = 0;
+
+  setProviderCapabilitiesOverrideForTesting('openai-codex', {
+    createCoderAdapter() {
+      return {
+        async runPrompt() {
+          promptCalls += 1;
+          throw new Error('provider should not be called');
+        },
+        async runStructuredPrompt() {
+          promptCalls += 1;
+          throw new Error('provider should not be called');
+        },
+      };
+    },
+  });
+
+  try {
+    await assert.rejects(
+      () => withProcessCwd(cwd, () => captureProcessOutput(() =>
+        runResumeRunCommand(['resume', '--run', runId, '--message', 'Try one narrow fix.']),
+      )),
+      /Invalid review level for neal\.review_level: "paranoid"\. Valid values: strict, moderate, lenient/,
+    );
+  } finally {
+    clearProviderCapabilitiesOverridesForTesting();
+    clearConfigCache(cwd);
+  }
+
+  assert.equal(promptCalls, 0);
+  assert.equal(await readFile(getRunStatePath(blockedState.runDir), 'utf8'), stateBefore);
+  assert.deepEqual(await readRunEventTypes(blockedState.runDir), eventsBefore);
+});
+
+test('neal resume on a done run reports already done even when review_level is invalid', async () => {
+  const { cwd, loaded } = await createRepoRunFixture('neal-resume-done-invalid-review-level-');
+  const doneState = await saveState(loaded.statePath, {
+    ...loaded.state,
+    phase: 'done',
+    status: 'done',
+  });
+  const runId = basename(doneState.runDir);
+  const before = await readFile(getRunStatePath(doneState.runDir), 'utf8');
+  await writeFile(join(cwd, 'neal.yml'), 'neal:\n  review_level: paranoid\n', 'utf8');
+  clearConfigCache(cwd);
+
+  try {
+    const { result, exitCode } = await captureProcessExitCode(() => withProcessCwd(cwd, () =>
+      captureProcessOutput(() => runResumeRunCommand(['resume', '--run', runId])),
+    ));
+
+    assert.equal(exitCode, 0);
+    assert.match(result.stdout, /already complete/);
+  } finally {
+    clearConfigCache(cwd);
+  }
+
+  assert.equal(await readFile(getRunStatePath(doneState.runDir), 'utf8'), before);
+});
+
+test('neal resume on a live same-run lock reports already running even when review_level is invalid', async () => {
+  const { cwd, loaded } = await createRepoRunFixture('neal-resume-running-invalid-review-level-');
+  const failedState = await saveState(loaded.statePath, {
+    ...loaded.state,
+    phase: 'coder_scope',
+    status: 'failed',
+  });
+  const runId = basename(failedState.runDir);
+  const before = await readFile(getRunStatePath(failedState.runDir), 'utf8');
+  await writeActiveRunLock(cwd, runId, failedState.planDoc);
+  await writeFile(join(cwd, 'neal.yml'), 'neal:\n  review_level: paranoid\n', 'utf8');
+  clearConfigCache(cwd);
+
+  try {
+    const { result, exitCode } = await captureProcessExitCode(() => withProcessCwd(cwd, () =>
+      captureProcessOutput(() => runResumeRunCommand(['resume', '--run', runId])),
+    ));
+
+    assert.equal(exitCode, 2);
+    assert.match(result.stdout, /already be running/);
+  } finally {
+    clearConfigCache(cwd);
+  }
+
+  assert.equal(await readFile(getRunStatePath(failedState.runDir), 'utf8'), before);
 });
 
 test('neal resume on a done run does not call provider execution or mutate state', async () => {

--- a/test/prompt-render-integrity.test.ts
+++ b/test/prompt-render-integrity.test.ts
@@ -31,6 +31,7 @@ import { clearUserGuidanceCache } from '../src/neal/prompts/guidance.js';
 import { createInlineSection, type InlineReviewerContext } from '../src/neal/context/inline-review-context.js';
 import { renderReviewerContextMarkdown, type ReviewerContextPacket } from '../src/neal/context/reviewer-context.js';
 import type { ReviewDoctrineAccessMode } from '../src/neal/prompts/review-doctrine.js';
+import type { ReviewLevel } from '../src/neal/config.js';
 import type { FinalCompletionPacket, FinalCompletionSummary } from '../src/neal/types.js';
 
 // Deterministic renders: point guidance at a nonexistent dir and clear the cache
@@ -260,6 +261,8 @@ const CANNED_COMPLETION_PACKET_UNAVAILABLE: FinalCompletionPacket = {
 // `authoredOneShot`); it excludes pure data interpolation. The `accessMode` axis for the two range-diff
 // reviewers encodes the read-only submode: `read-only-inlined` supplies a canned
 // inlined range diff, `read-only-tool` omits it (the providesRangeDiffTool case).
+// The `reviewLevel` axis on the same two reviewers selects the level-calibration
+// doctrine (`strict`, `moderate`, `lenient`).
 // ---------------------------------------------------------------------------
 
 type AxisSpec = { name: string; values: string[] };
@@ -269,6 +272,8 @@ type BuilderMatrixSpec = {
   axes: AxisSpec[];
   render: (combo: Combo) => string;
 };
+
+const REVIEW_LEVEL_AXIS_VALUES: ReviewLevel[] = ['strict', 'moderate', 'lenient'];
 
 function reviewerAccessMode(value: string): ReviewDoctrineAccessMode {
   if (value === 'tool-access') {
@@ -381,6 +386,7 @@ const reviewerSpec: BuilderMatrixSpec = {
     { name: 'accessMode', values: ['tool-access', 'read-only-inlined', 'read-only-tool'] },
     { name: 'earlierScopeChanges', values: ['present', 'absent'] },
     { name: 'previousHead', values: ['present', 'absent'] },
+    { name: 'reviewLevel', values: REVIEW_LEVEL_AXIS_VALUES },
   ],
   render: (c) => {
     const accessMode = reviewerAccessMode(c.accessMode);
@@ -402,6 +408,7 @@ const reviewerSpec: BuilderMatrixSpec = {
       inlinedRangeDiff: c.accessMode === 'read-only-inlined' ? CANNED_RANGE_DIFF : null,
       earlierScopeChanges: c.earlierScopeChanges === 'present' ? CANNED_EARLIER_SCOPE_CHANGES : null,
       accessMode,
+      reviewLevel: c.reviewLevel as ReviewLevel,
     });
   },
 };
@@ -425,6 +432,7 @@ function renderCompletionReviewer(c: Combo): string {
     // collected); the unavailable spec omits that submode entirely.
     inlinedRangeDiff: c.accessMode === 'read-only-inlined' ? CANNED_RANGE_DIFF : null,
     accessMode,
+    reviewLevel: c.reviewLevel as ReviewLevel,
   });
 }
 
@@ -436,6 +444,7 @@ const finalCompletionReviewerAvailableSpec: BuilderMatrixSpec = {
   axes: [
     { name: 'accessMode', values: ['tool-access', 'read-only-inlined', 'read-only-tool'] },
     { name: 'aggregateRange', values: ['available'] },
+    { name: 'reviewLevel', values: REVIEW_LEVEL_AXIS_VALUES },
   ],
   render: renderCompletionReviewer,
 };
@@ -445,6 +454,7 @@ const finalCompletionReviewerUnavailableSpec: BuilderMatrixSpec = {
   axes: [
     { name: 'accessMode', values: ['tool-access', 'read-only-tool'] },
     { name: 'aggregateRange', values: ['unavailable'] },
+    { name: 'reviewLevel', values: REVIEW_LEVEL_AXIS_VALUES },
   ],
   render: renderCompletionReviewer,
 };
@@ -570,34 +580,68 @@ const EXPECTED_KEYS: Record<PromptSpecId, string[]> = {
     'buildScopePrompt',
   ],
   scope_reviewer: [
-    'buildReviewerPrompt#accessMode=read-only-inlined#earlierScopeChanges=present#previousHead=absent',
-    'buildReviewerPrompt#accessMode=read-only-inlined#earlierScopeChanges=present#previousHead=present',
-    'buildReviewerPrompt#accessMode=read-only-tool#earlierScopeChanges=present#previousHead=absent',
-    'buildReviewerPrompt#accessMode=read-only-tool#earlierScopeChanges=present#previousHead=present',
-    'buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=present#previousHead=absent',
-    'buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=present#previousHead=present',
-    'buildReviewerPrompt#accessMode=read-only-inlined#earlierScopeChanges=absent#previousHead=absent',
-    'buildReviewerPrompt#accessMode=read-only-inlined#earlierScopeChanges=absent#previousHead=present',
-    'buildReviewerPrompt#accessMode=read-only-tool#earlierScopeChanges=absent#previousHead=absent',
-    'buildReviewerPrompt#accessMode=read-only-tool#earlierScopeChanges=absent#previousHead=present',
-    'buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=absent#previousHead=absent',
-    'buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=absent#previousHead=present',
+    'buildReviewerPrompt#accessMode=read-only-inlined#earlierScopeChanges=present#previousHead=absent#reviewLevel=strict',
+    'buildReviewerPrompt#accessMode=read-only-inlined#earlierScopeChanges=present#previousHead=absent#reviewLevel=moderate',
+    'buildReviewerPrompt#accessMode=read-only-inlined#earlierScopeChanges=present#previousHead=absent#reviewLevel=lenient',
+    'buildReviewerPrompt#accessMode=read-only-inlined#earlierScopeChanges=present#previousHead=present#reviewLevel=strict',
+    'buildReviewerPrompt#accessMode=read-only-inlined#earlierScopeChanges=present#previousHead=present#reviewLevel=moderate',
+    'buildReviewerPrompt#accessMode=read-only-inlined#earlierScopeChanges=present#previousHead=present#reviewLevel=lenient',
+    'buildReviewerPrompt#accessMode=read-only-tool#earlierScopeChanges=present#previousHead=absent#reviewLevel=strict',
+    'buildReviewerPrompt#accessMode=read-only-tool#earlierScopeChanges=present#previousHead=absent#reviewLevel=moderate',
+    'buildReviewerPrompt#accessMode=read-only-tool#earlierScopeChanges=present#previousHead=absent#reviewLevel=lenient',
+    'buildReviewerPrompt#accessMode=read-only-tool#earlierScopeChanges=present#previousHead=present#reviewLevel=strict',
+    'buildReviewerPrompt#accessMode=read-only-tool#earlierScopeChanges=present#previousHead=present#reviewLevel=moderate',
+    'buildReviewerPrompt#accessMode=read-only-tool#earlierScopeChanges=present#previousHead=present#reviewLevel=lenient',
+    'buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=present#previousHead=absent#reviewLevel=strict',
+    'buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=present#previousHead=absent#reviewLevel=moderate',
+    'buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=present#previousHead=absent#reviewLevel=lenient',
+    'buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=present#previousHead=present#reviewLevel=strict',
+    'buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=present#previousHead=present#reviewLevel=moderate',
+    'buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=present#previousHead=present#reviewLevel=lenient',
+    'buildReviewerPrompt#accessMode=read-only-inlined#earlierScopeChanges=absent#previousHead=absent#reviewLevel=strict',
+    'buildReviewerPrompt#accessMode=read-only-inlined#earlierScopeChanges=absent#previousHead=absent#reviewLevel=moderate',
+    'buildReviewerPrompt#accessMode=read-only-inlined#earlierScopeChanges=absent#previousHead=absent#reviewLevel=lenient',
+    'buildReviewerPrompt#accessMode=read-only-inlined#earlierScopeChanges=absent#previousHead=present#reviewLevel=strict',
+    'buildReviewerPrompt#accessMode=read-only-inlined#earlierScopeChanges=absent#previousHead=present#reviewLevel=moderate',
+    'buildReviewerPrompt#accessMode=read-only-inlined#earlierScopeChanges=absent#previousHead=present#reviewLevel=lenient',
+    'buildReviewerPrompt#accessMode=read-only-tool#earlierScopeChanges=absent#previousHead=absent#reviewLevel=strict',
+    'buildReviewerPrompt#accessMode=read-only-tool#earlierScopeChanges=absent#previousHead=absent#reviewLevel=moderate',
+    'buildReviewerPrompt#accessMode=read-only-tool#earlierScopeChanges=absent#previousHead=absent#reviewLevel=lenient',
+    'buildReviewerPrompt#accessMode=read-only-tool#earlierScopeChanges=absent#previousHead=present#reviewLevel=strict',
+    'buildReviewerPrompt#accessMode=read-only-tool#earlierScopeChanges=absent#previousHead=present#reviewLevel=moderate',
+    'buildReviewerPrompt#accessMode=read-only-tool#earlierScopeChanges=absent#previousHead=present#reviewLevel=lenient',
+    'buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=absent#previousHead=absent#reviewLevel=strict',
+    'buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=absent#previousHead=absent#reviewLevel=moderate',
+    'buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=absent#previousHead=absent#reviewLevel=lenient',
+    'buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=absent#previousHead=present#reviewLevel=strict',
+    'buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=absent#previousHead=present#reviewLevel=moderate',
+    'buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=absent#previousHead=present#reviewLevel=lenient',
   ],
   completion_coder: ['buildFinalCompletionSummaryPrompt'],
   completion_reviewer: [
-    'buildFinalCompletionReviewerPrompt#accessMode=read-only-inlined#aggregateRange=available',
-    'buildFinalCompletionReviewerPrompt#accessMode=read-only-tool#aggregateRange=available',
-    'buildFinalCompletionReviewerPrompt#accessMode=read-only-tool#aggregateRange=unavailable',
-    'buildFinalCompletionReviewerPrompt#accessMode=tool-access#aggregateRange=available',
-    'buildFinalCompletionReviewerPrompt#accessMode=tool-access#aggregateRange=unavailable',
+    'buildFinalCompletionReviewerPrompt#accessMode=read-only-inlined#aggregateRange=available#reviewLevel=strict',
+    'buildFinalCompletionReviewerPrompt#accessMode=read-only-inlined#aggregateRange=available#reviewLevel=moderate',
+    'buildFinalCompletionReviewerPrompt#accessMode=read-only-inlined#aggregateRange=available#reviewLevel=lenient',
+    'buildFinalCompletionReviewerPrompt#accessMode=read-only-tool#aggregateRange=available#reviewLevel=strict',
+    'buildFinalCompletionReviewerPrompt#accessMode=read-only-tool#aggregateRange=available#reviewLevel=moderate',
+    'buildFinalCompletionReviewerPrompt#accessMode=read-only-tool#aggregateRange=available#reviewLevel=lenient',
+    'buildFinalCompletionReviewerPrompt#accessMode=read-only-tool#aggregateRange=unavailable#reviewLevel=strict',
+    'buildFinalCompletionReviewerPrompt#accessMode=read-only-tool#aggregateRange=unavailable#reviewLevel=moderate',
+    'buildFinalCompletionReviewerPrompt#accessMode=read-only-tool#aggregateRange=unavailable#reviewLevel=lenient',
+    'buildFinalCompletionReviewerPrompt#accessMode=tool-access#aggregateRange=available#reviewLevel=strict',
+    'buildFinalCompletionReviewerPrompt#accessMode=tool-access#aggregateRange=available#reviewLevel=moderate',
+    'buildFinalCompletionReviewerPrompt#accessMode=tool-access#aggregateRange=available#reviewLevel=lenient',
+    'buildFinalCompletionReviewerPrompt#accessMode=tool-access#aggregateRange=unavailable#reviewLevel=strict',
+    'buildFinalCompletionReviewerPrompt#accessMode=tool-access#aggregateRange=unavailable#reviewLevel=moderate',
+    'buildFinalCompletionReviewerPrompt#accessMode=tool-access#aggregateRange=unavailable#reviewLevel=lenient',
   ],
   consultant: ['buildConsultantPrompt'],
 };
 
 const EXPECTED_MODULE_SHAS: Record<(typeof MATRIX_BUILDER_MODULES)[number], string> = {
   'src/neal/prompts/planning.ts': '0d0e88130af09545f7bfb5d74bf03d333954152baabd37a7926279e361167cde',
-  'src/neal/prompts/execute.ts': '9676b2ac04e64317788a4769958cd3eb09d26931242f7204a30624ba8fec35ad',
-  'src/neal/prompts/specialized.ts': 'c5e4ceeff6bbce7fbcfa6e97b591724528e09b5315f1dcb4dab7eedc4195362c',
+  'src/neal/prompts/execute.ts': '2b94a85d63e08bd676bdb2415eb9c1de2f27cdce6e858ee220cfb44c18dacfb0',
+  'src/neal/prompts/specialized.ts': '396c46ab85aa4e41ef0bf5cbce5c84d0dd11210d07b25a4c58327fd615ca8683',
   'src/neal/agents/prompts.ts': 'c9b8b6bd135206ec8c7055aa887d65003490b8fdef95c3a662797018d01a667e',
   'src/neal/context/reviewer-context.ts': '7168f61b26ff2c9fb9fa67ce7c608f452722fcfc5187f8c346910264a4c00674',
   'src/neal/context/inline-review-context.ts': 'e6b355023bc3736d0958a4fe253eab9e0ab6df321b21190c67e766623de6a029',
@@ -657,14 +701,18 @@ function assertSentinelPresence(cellKey: string, render: string, sentinel: strin
 // (whose render must not contain that sentinel). Covers every authored axis:
 // authoredOneShot, previousHead, terminalOnly, allowReplacement,
 // allowLaterScopeRevision, both response
-// modes, plan/derived-plan modes, and every reviewer access submode of both
-// range-diff reviewers.
+// modes, plan/derived-plan modes, every reviewer access submode of both
+// range-diff reviewers, and every review level of both range-diff reviewers.
 type AxisConformanceCase = { withKey: string; withoutKey: string; sentinel: string };
 
 const GIT_COMMANDS_SENTINEL = 'Use git commands against the repository';
 const GIT_DIFF_TOOL_SENTINEL = 'use the git_diff tool';
 const INLINED_RANGE_DIFF_SENTINEL = '## Inlined commit-range diff from Neal';
 const EARLIER_SCOPE_CHANGES_SENTINEL = '## Earlier-scope changes to files in this diff';
+const STRICT_LEVEL_SENTINEL = 'Review level: strict.';
+const MODERATE_LEVEL_SENTINEL = 'Review level: moderate.';
+const LENIENT_LEVEL_SENTINEL = 'Review level: lenient.';
+const LENIENT_FINDING_QUALITY_SENTINEL = 'are non_blocking unless they are a reachable correctness failure';
 
 const AXIS_CONFORMANCE: AxisConformanceCase[] = [
   // authoredOneShot
@@ -681,14 +729,14 @@ const AXIS_CONFORMANCE: AxisConformanceCase[] = [
   // earlierScopeChanges present/absent on buildReviewerPrompt: the section
   // renders only with an overlap; the preservation rule renders either way.
   {
-    withKey: 'buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=present#previousHead=present',
-    withoutKey: 'buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=absent#previousHead=present',
+    withKey: 'buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=present#previousHead=present#reviewLevel=moderate',
+    withoutKey: 'buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=absent#previousHead=present#reviewLevel=moderate',
     sentinel: EARLIER_SCOPE_CHANGES_SENTINEL,
   },
   // previousHead
   {
-    withKey: 'buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=absent#previousHead=present',
-    withoutKey: 'buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=absent#previousHead=absent',
+    withKey: 'buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=absent#previousHead=present#reviewLevel=moderate',
+    withoutKey: 'buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=absent#previousHead=absent#reviewLevel=moderate',
     sentinel: 'Previous reviewer head was',
   },
   // terminalOnly / allowReplacement / allowLaterScopeRevision
@@ -742,34 +790,34 @@ const AXIS_CONFORMANCE: AxisConformanceCase[] = [
   },
   // buildReviewerPrompt access submodes
   {
-    withKey: 'buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=absent#previousHead=present',
-    withoutKey: 'buildReviewerPrompt#accessMode=read-only-tool#earlierScopeChanges=absent#previousHead=present',
+    withKey: 'buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=absent#previousHead=present#reviewLevel=moderate',
+    withoutKey: 'buildReviewerPrompt#accessMode=read-only-tool#earlierScopeChanges=absent#previousHead=present#reviewLevel=moderate',
     sentinel: GIT_COMMANDS_SENTINEL,
   },
   {
-    withKey: 'buildReviewerPrompt#accessMode=read-only-inlined#earlierScopeChanges=absent#previousHead=present',
-    withoutKey: 'buildReviewerPrompt#accessMode=read-only-tool#earlierScopeChanges=absent#previousHead=present',
+    withKey: 'buildReviewerPrompt#accessMode=read-only-inlined#earlierScopeChanges=absent#previousHead=present#reviewLevel=moderate',
+    withoutKey: 'buildReviewerPrompt#accessMode=read-only-tool#earlierScopeChanges=absent#previousHead=present#reviewLevel=moderate',
     sentinel: INLINED_RANGE_DIFF_SENTINEL,
   },
   {
-    withKey: 'buildReviewerPrompt#accessMode=read-only-tool#earlierScopeChanges=absent#previousHead=present',
-    withoutKey: 'buildReviewerPrompt#accessMode=read-only-inlined#earlierScopeChanges=absent#previousHead=present',
+    withKey: 'buildReviewerPrompt#accessMode=read-only-tool#earlierScopeChanges=absent#previousHead=present#reviewLevel=moderate',
+    withoutKey: 'buildReviewerPrompt#accessMode=read-only-inlined#earlierScopeChanges=absent#previousHead=present#reviewLevel=moderate',
     sentinel: GIT_DIFF_TOOL_SENTINEL,
   },
   // buildFinalCompletionReviewerPrompt access submodes (aggregate range available)
   {
-    withKey: 'buildFinalCompletionReviewerPrompt#accessMode=tool-access#aggregateRange=available',
-    withoutKey: 'buildFinalCompletionReviewerPrompt#accessMode=read-only-tool#aggregateRange=available',
+    withKey: 'buildFinalCompletionReviewerPrompt#accessMode=tool-access#aggregateRange=available#reviewLevel=moderate',
+    withoutKey: 'buildFinalCompletionReviewerPrompt#accessMode=read-only-tool#aggregateRange=available#reviewLevel=moderate',
     sentinel: GIT_COMMANDS_SENTINEL,
   },
   {
-    withKey: 'buildFinalCompletionReviewerPrompt#accessMode=read-only-inlined#aggregateRange=available',
-    withoutKey: 'buildFinalCompletionReviewerPrompt#accessMode=read-only-tool#aggregateRange=available',
+    withKey: 'buildFinalCompletionReviewerPrompt#accessMode=read-only-inlined#aggregateRange=available#reviewLevel=moderate',
+    withoutKey: 'buildFinalCompletionReviewerPrompt#accessMode=read-only-tool#aggregateRange=available#reviewLevel=moderate',
     sentinel: INLINED_RANGE_DIFF_SENTINEL,
   },
   {
-    withKey: 'buildFinalCompletionReviewerPrompt#accessMode=read-only-tool#aggregateRange=available',
-    withoutKey: 'buildFinalCompletionReviewerPrompt#accessMode=read-only-inlined#aggregateRange=available',
+    withKey: 'buildFinalCompletionReviewerPrompt#accessMode=read-only-tool#aggregateRange=available#reviewLevel=moderate',
+    withoutKey: 'buildFinalCompletionReviewerPrompt#accessMode=read-only-inlined#aggregateRange=available#reviewLevel=moderate',
     sentinel: GIT_DIFF_TOOL_SENTINEL,
   },
   // buildPlanReviewerPrompt access modes: tool-access vs read-only
@@ -801,14 +849,52 @@ const AXIS_CONFORMANCE: AxisConformanceCase[] = [
   // the range-anchored falsification line; unavailable has no resolved range so
   // that line is absent.
   {
-    withKey: 'buildFinalCompletionReviewerPrompt#accessMode=tool-access#aggregateRange=available',
-    withoutKey: 'buildFinalCompletionReviewerPrompt#accessMode=tool-access#aggregateRange=unavailable',
+    withKey: 'buildFinalCompletionReviewerPrompt#accessMode=tool-access#aggregateRange=available#reviewLevel=moderate',
+    withoutKey: 'buildFinalCompletionReviewerPrompt#accessMode=tool-access#aggregateRange=unavailable#reviewLevel=moderate',
     sentinel: 'Review that aggregate range base000..head000 directly with repository tools',
   },
   {
-    withKey: 'buildFinalCompletionReviewerPrompt#accessMode=read-only-tool#aggregateRange=available',
-    withoutKey: 'buildFinalCompletionReviewerPrompt#accessMode=read-only-tool#aggregateRange=unavailable',
+    withKey: 'buildFinalCompletionReviewerPrompt#accessMode=read-only-tool#aggregateRange=available#reviewLevel=moderate',
+    withoutKey: 'buildFinalCompletionReviewerPrompt#accessMode=read-only-tool#aggregateRange=unavailable#reviewLevel=moderate',
     sentinel: 'Review that aggregate range base000..head000 directly with your read-only repository tools',
+  },
+  // reviewLevel on buildReviewerPrompt: each level renders its own calibration
+  // line; only lenient narrows the robustness/performance severity rule.
+  {
+    withKey: 'buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=absent#previousHead=present#reviewLevel=strict',
+    withoutKey: 'buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=absent#previousHead=present#reviewLevel=moderate',
+    sentinel: STRICT_LEVEL_SENTINEL,
+  },
+  {
+    withKey: 'buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=absent#previousHead=present#reviewLevel=moderate',
+    withoutKey: 'buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=absent#previousHead=present#reviewLevel=lenient',
+    sentinel: MODERATE_LEVEL_SENTINEL,
+  },
+  {
+    withKey: 'buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=absent#previousHead=present#reviewLevel=lenient',
+    withoutKey: 'buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=absent#previousHead=present#reviewLevel=strict',
+    sentinel: LENIENT_LEVEL_SENTINEL,
+  },
+  {
+    withKey: 'buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=absent#previousHead=present#reviewLevel=lenient',
+    withoutKey: 'buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=absent#previousHead=present#reviewLevel=moderate',
+    sentinel: LENIENT_FINDING_QUALITY_SENTINEL,
+  },
+  // reviewLevel on buildFinalCompletionReviewerPrompt.
+  {
+    withKey: 'buildFinalCompletionReviewerPrompt#accessMode=tool-access#aggregateRange=available#reviewLevel=strict',
+    withoutKey: 'buildFinalCompletionReviewerPrompt#accessMode=tool-access#aggregateRange=available#reviewLevel=moderate',
+    sentinel: STRICT_LEVEL_SENTINEL,
+  },
+  {
+    withKey: 'buildFinalCompletionReviewerPrompt#accessMode=tool-access#aggregateRange=available#reviewLevel=moderate',
+    withoutKey: 'buildFinalCompletionReviewerPrompt#accessMode=tool-access#aggregateRange=available#reviewLevel=lenient',
+    sentinel: MODERATE_LEVEL_SENTINEL,
+  },
+  {
+    withKey: 'buildFinalCompletionReviewerPrompt#accessMode=read-only-tool#aggregateRange=unavailable#reviewLevel=lenient',
+    withoutKey: 'buildFinalCompletionReviewerPrompt#accessMode=read-only-tool#aggregateRange=unavailable#reviewLevel=strict',
+    sentinel: LENIENT_LEVEL_SENTINEL,
   },
 ];
 
@@ -855,7 +941,7 @@ function registerTests(): void {
 
   test('reviewer access-mode branches render distinctly (both read-only submodes covered)', () => {
     const render = (accessMode: string, previousHead: string) =>
-      reviewerSpec.render({ accessMode, earlierScopeChanges: 'absent', previousHead });
+      reviewerSpec.render({ accessMode, earlierScopeChanges: 'absent', previousHead, reviewLevel: 'moderate' });
     const toolAccess = render('tool-access', 'present');
     const readOnlyInlined = render('read-only-inlined', 'present');
     const readOnlyTool = render('read-only-tool', 'present');
@@ -887,8 +973,8 @@ function registerTests(): void {
   test('reviewer cells render production continuity framing and plan content per access mode', () => {
     // scope reviewer: every mode gets the tool-access citations framing (the
     // removed no-read inline framing must never render).
-    const scopeToolAccess = cellRenderByKey('buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=absent#previousHead=present');
-    const scopeReadOnly = cellRenderByKey('buildReviewerPrompt#accessMode=read-only-inlined#earlierScopeChanges=absent#previousHead=present');
+    const scopeToolAccess = cellRenderByKey('buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=absent#previousHead=present#reviewLevel=moderate');
+    const scopeReadOnly = cellRenderByKey('buildReviewerPrompt#accessMode=read-only-inlined#earlierScopeChanges=absent#previousHead=present#reviewLevel=moderate');
     for (const render of [scopeToolAccess, scopeReadOnly]) {
       assert.ok(render.includes('# Reviewer Continuity Context'), 'scope reviewer must render the continuity block');
       assert.ok(render.includes('Inspect cited artifacts'));
@@ -917,10 +1003,10 @@ function registerTests(): void {
 
     // completion reviewer: same tool-access continuity framing everywhere.
     const complToolAccess = cellRenderByKey(
-      'buildFinalCompletionReviewerPrompt#accessMode=tool-access#aggregateRange=available',
+      'buildFinalCompletionReviewerPrompt#accessMode=tool-access#aggregateRange=available#reviewLevel=moderate',
     );
     const complReadOnly = cellRenderByKey(
-      'buildFinalCompletionReviewerPrompt#accessMode=read-only-tool#aggregateRange=available',
+      'buildFinalCompletionReviewerPrompt#accessMode=read-only-tool#aggregateRange=available#reviewLevel=moderate',
     );
     for (const render of [complToolAccess, complReadOnly]) {
       assert.ok(render.includes('Inspect cited artifacts'));
@@ -974,12 +1060,14 @@ function registerTests(): void {
       'buildBlockedRecoveryCoderPrompt#allowLaterScopeRevision=false#allowReplacement=false#terminalOnly=true',
       'buildBlockedRecoveryCoderPrompt#allowLaterScopeRevision=false#allowReplacement=true#terminalOnly=false',
       'buildBlockedRecoveryCoderPrompt#allowLaterScopeRevision=true#allowReplacement=true#terminalOnly=false',
-      'buildReviewerPrompt#accessMode=read-only-inlined#earlierScopeChanges=absent#previousHead=present',
-      'buildReviewerPrompt#accessMode=read-only-tool#earlierScopeChanges=absent#previousHead=present',
+      'buildReviewerPrompt#accessMode=read-only-inlined#earlierScopeChanges=absent#previousHead=present#reviewLevel=moderate',
+      'buildReviewerPrompt#accessMode=read-only-tool#earlierScopeChanges=absent#previousHead=present#reviewLevel=moderate',
       // New authored axes (R2-F1): planDocument, planReviewGuidance, aggregate-range.
       'buildPlanningPrompt#authoredOneShot=false#planDocument=present',
       'buildCoderPlanResponsePrompt#mode=blocking#planReviewGuidance=present#reviewMode=plan',
-      'buildFinalCompletionReviewerPrompt#accessMode=read-only-tool#aggregateRange=unavailable',
+      'buildFinalCompletionReviewerPrompt#accessMode=read-only-tool#aggregateRange=unavailable#reviewLevel=moderate',
+      'buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=absent#previousHead=present#reviewLevel=lenient',
+      'buildFinalCompletionReviewerPrompt#accessMode=tool-access#aggregateRange=available#reviewLevel=strict',
     ];
     for (const key of perturbedKeys) {
       const { specId, cells } = findCell(key);

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -3260,3 +3260,226 @@ test('scope reviewer prompt renders earlier-scope per-file diffs when supplied a
     assert.match(prompt, /Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding/);
   }
 });
+
+// --- Review-level calibration ---
+// The configured `neal.review_level` reaches both code reviewers as a builder
+// argument. Every level renders its own trust-boundary line; the reachability
+// filter, the guidance merge rule, and the adversarial stance render under all
+// of them.
+
+const REVIEW_LEVELS = ['strict', 'moderate', 'lenient'] as const;
+
+const REVIEW_LEVEL_SCOPE_ARGS = {
+  planDoc: '/tmp/PLAN.md',
+  baseCommit: 'base123',
+  headCommit: 'head456',
+  commits: ['head456 add gate logic'],
+  previousHeadCommit: null,
+  diffStat: ' src/neal/orchestrator.ts | 10 +++++-----',
+  changedFiles: ['src/neal/orchestrator.ts'],
+  round: 1,
+  reviewMarkdownPath: '/tmp/REVIEW.md',
+  parentScopeLabel: '1',
+  progressJustification: {
+    milestoneTargeted: 'Review-level calibration',
+    newEvidence: 'The level reaches the prompt.',
+    whyNotRedundant: 'No prior scope rendered the level.',
+    nextStepUnlocked: 'Reviewers calibrate to the configured level.',
+  },
+  recentHistorySummary: 'No accepted scopes have been recorded yet for parent objective 1.',
+  scratchDir: '/tmp/repo/.neal/runs/run-123/scratch/reviewer-scope-1-round-1',
+};
+
+async function createReviewLevelCompletionArgs() {
+  const { state } = await createState({
+    currentScopeNumber: 2,
+    executionShape: 'multi_scope',
+    completedScopes: [
+      {
+        number: '1',
+        marker: 'AUTONOMY_SCOPE_DONE',
+        result: 'accepted',
+        baseCommit: 'base-1',
+        finalCommit: 'final-1',
+        commitSubject: 'implement scope 1',
+        changedFiles: ['src/a.ts'],
+        reviewRounds: 1,
+        findings: 0,
+        archivedReviewPath: '/tmp/review-1.md',
+        blocker: null,
+        derivedFromParentScope: null,
+        replacedByDerivedPlanPath: null,
+      },
+    ],
+  });
+  const packet = await buildFinalCompletionPacket({
+    state,
+    terminalScope: {
+      finalCommit: 'final-2',
+      commitSubject: 'finish scope 2',
+      changedFiles: ['src/b.ts'],
+      archivedReviewPath: '/tmp/review-2.md',
+      marker: 'AUTONOMY_DONE',
+    },
+  });
+  return {
+    planDoc: '/tmp/PLAN.md',
+    packet,
+    summary: {
+      planGoalSatisfied: true,
+      whatChangedOverall: 'Implemented the review-level calibration.',
+      verificationSummary: 'Ran review tests and typecheck.',
+      remainingKnownGaps: [],
+    },
+    scratchDir: '/tmp/repo/.neal/runs/run-123/scratch/final-completion-review',
+  };
+}
+
+const LEVEL_SENTINELS = {
+  strict: /Review level: strict\. Assume adversarial trust boundaries/,
+  moderate: /Review level: moderate\. Assume ordinary trust boundaries: internal run artifacts and other files this system writes for itself are not security boundaries/,
+  lenient: /Review level: lenient\. Assume ordinary trust boundaries and block only on correctness failures and real, reachable bugs/,
+} as const;
+
+function assertLevelInvariantDoctrine(prompt: string, demotedOutcome: RegExp) {
+  assert.match(prompt, /as hostile input\. Try to falsify/);
+  assert.match(prompt, /Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries/);
+  assert.match(prompt, /it never changes the inspection stance\. At every level, still treat the subject as hostile input, try to falsify before crediting/);
+  assert.match(prompt, /How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries/);
+  assert.match(prompt, /Guidance may widen or narrow the trust boundaries for this project/);
+  assert.match(prompt, /demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking/);
+  assert.match(prompt, /Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures \(including correctness regressions/);
+  assert.match(prompt, /Robustness, hardening, performance, and style are not part of that floor and may be demoted/);
+  assert.match(prompt, /guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks/);
+  assert.match(prompt, demotedOutcome);
+}
+
+test('scope reviewer prompt renders each review level with the reachability filter, merge rule, and adversarial stance intact', () => {
+  for (const level of REVIEW_LEVELS) {
+    const prompt = buildReviewerPrompt({ ...REVIEW_LEVEL_SCOPE_ARGS, reviewLevel: level });
+    assert.match(prompt, LEVEL_SENTINELS[level], `scope reviewer must render the ${level} calibration line`);
+    for (const other of REVIEW_LEVELS) {
+      if (other !== level) {
+        assert.doesNotMatch(prompt, LEVEL_SENTINELS[other], `scope reviewer at ${level} must not render the ${other} line`);
+      }
+    }
+    assertLevelInvariantDoctrine(
+      prompt,
+      /guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks/,
+    );
+    assert.match(prompt, /In this review a demoted category means non_blocking severity/);
+
+    // The calibration renders right after the adversarial doctrine and before
+    // the finding-quality rules.
+    const adversarialIndex = prompt.indexOf('Treat the scope diff as hostile input.');
+    const calibrationIndex = prompt.indexOf('Review level: ');
+    const findingQualityIndex = prompt.indexOf('Produce only structured review findings.');
+    assert.ok(adversarialIndex >= 0 && adversarialIndex < calibrationIndex && calibrationIndex < findingQualityIndex);
+  }
+});
+
+test('scope reviewer prompt defaults to the moderate level when no level is passed', () => {
+  assert.equal(
+    buildReviewerPrompt(REVIEW_LEVEL_SCOPE_ARGS),
+    buildReviewerPrompt({ ...REVIEW_LEVEL_SCOPE_ARGS, reviewLevel: 'moderate' }),
+  );
+});
+
+test('scope reviewer finding-quality severity line narrows under lenient only', () => {
+  const strict = buildReviewerPrompt({ ...REVIEW_LEVEL_SCOPE_ARGS, reviewLevel: 'strict' });
+  const moderate = buildReviewerPrompt({ ...REVIEW_LEVEL_SCOPE_ARGS, reviewLevel: 'moderate' });
+  const lenient = buildReviewerPrompt({ ...REVIEW_LEVEL_SCOPE_ARGS, reviewLevel: 'lenient' });
+  const blockingRobustnessLine = /Also use blocking severity for substantive robustness or performance regressions introduced by the implementation/;
+  const lenientLine = /Robustness or performance regressions introduced by the implementation are non_blocking unless they are a reachable correctness failure; use blocking severity only in that case\./;
+
+  assert.match(strict, blockingRobustnessLine);
+  assert.match(moderate, blockingRobustnessLine);
+  assert.doesNotMatch(lenient, blockingRobustnessLine);
+  assert.match(lenient, lenientLine);
+  assert.doesNotMatch(strict, lenientLine);
+  assert.doesNotMatch(moderate, lenientLine);
+
+  const findingQuality = (prompt: string) => prompt.slice(prompt.indexOf('Produce only structured review findings.'));
+  assert.equal(findingQuality(strict), findingQuality(moderate));
+  assert.notEqual(findingQuality(lenient), findingQuality(moderate));
+  // Every level keeps the correctness floor in the severity rules.
+  for (const prompt of [strict, moderate, lenient]) {
+    assert.match(prompt, /Use blocking severity for correctness, regression, or missing-verification issues\./);
+  }
+});
+
+test('final completion reviewer prompt renders each review level and maps demoted categories onto the existing verdict', async () => {
+  const baseArgs = await createReviewLevelCompletionArgs();
+  for (const level of REVIEW_LEVELS) {
+    const prompt = buildFinalCompletionReviewerPrompt({ ...baseArgs, reviewLevel: level });
+    assert.match(prompt, LEVEL_SENTINELS[level], `final completion reviewer must render the ${level} calibration line`);
+    for (const other of REVIEW_LEVELS) {
+      if (other !== level) {
+        assert.doesNotMatch(prompt, LEVEL_SENTINELS[other]);
+      }
+    }
+    assertLevelInvariantDoctrine(
+      prompt,
+      /guidance saying "ignore performance, correctness only" makes a performance regression not missing work, while a reachable correctness failure still blocks/,
+    );
+    assert.match(prompt, /In this review a demoted or ignored category is not missing work: it must not produce `continue_execution` or `block_for_operator`, and when the plan objectives are otherwise satisfied you return `accept_complete`\./);
+    assert.match(prompt, /A finding category that the review level or the User Guidance section has demoted or ignored is not missing work: never return `continue_execution` or `block_for_operator` for it\. When the plan objectives are otherwise satisfied, return `accept_complete`\./);
+    // No scope-review severity vocabulary leaks into the verdict contract.
+    assert.doesNotMatch(prompt, /non_blocking severity/);
+
+    const adversarialIndex = prompt.indexOf('Treat the whole-plan completion claim as hostile input.');
+    const calibrationIndex = prompt.indexOf('Review level: ');
+    assert.ok(adversarialIndex >= 0 && adversarialIndex < calibrationIndex);
+  }
+  assert.equal(
+    buildFinalCompletionReviewerPrompt(baseArgs),
+    buildFinalCompletionReviewerPrompt({ ...baseArgs, reviewLevel: 'moderate' }),
+  );
+});
+
+test('reviewer guidance renders after the review-level calibration in both code-reviewer prompts', async () => {
+  const previousGuidanceDir = process.env.NEAL_GUIDANCE_DIR;
+  const guidanceDir = await mkdtemp(join(tmpdir(), 'neal-review-level-guidance-'));
+  await writeFile(join(guidanceDir, 'reviewer.md'), 'We do defend the run directory against local processes.\n', 'utf8');
+  process.env.NEAL_GUIDANCE_DIR = guidanceDir;
+  clearUserGuidanceCache();
+  try {
+    const completionArgs = await createReviewLevelCompletionArgs();
+    for (const level of REVIEW_LEVELS) {
+      for (const prompt of [
+        buildReviewerPrompt({ ...REVIEW_LEVEL_SCOPE_ARGS, reviewLevel: level }),
+        buildFinalCompletionReviewerPrompt({ ...completionArgs, reviewLevel: level }),
+      ]) {
+        const calibrationIndex = prompt.indexOf('Review level: ');
+        const floorIndex = prompt.indexOf('Fixed floor at every level and under any guidance');
+        const guidanceIndex = prompt.indexOf('## User Guidance');
+        assert.ok(calibrationIndex >= 0);
+        assert.ok(floorIndex > calibrationIndex);
+        assert.ok(guidanceIndex > floorIndex, `guidance must render after the ${level} calibration`);
+        assert.match(prompt, /We do defend the run directory against local processes\./);
+      }
+    }
+  } finally {
+    if (previousGuidanceDir === undefined) {
+      delete process.env.NEAL_GUIDANCE_DIR;
+    } else {
+      process.env.NEAL_GUIDANCE_DIR = previousGuidanceDir;
+    }
+    clearUserGuidanceCache();
+  }
+});
+
+test('scope review round resolves neal.review_level from the repository config and passes it to the built prompt', async () => {
+  const { state } = await createScopeReviewCaptureFixture('anthropic-claude');
+  await writeFile(join(state.cwd, 'neal.yml'), 'neal:\n  notify_bin: /usr/bin/true\n  review_level: strict\n', 'utf8');
+  clearConfigCache(state.cwd);
+  const captured = installCapturingScopeReviewAdvisor('anthropic-claude');
+
+  await runRealScopeReviewAdjudication(state);
+
+  assert.equal(captured.length, 1);
+  const prompt = captured[0]!.prompt;
+  assert.match(prompt, LEVEL_SENTINELS.strict);
+  assert.doesNotMatch(prompt, LEVEL_SENTINELS.moderate);
+  assert.match(prompt, /Reachability filter: a blocking finding must describe a failure that is reachable/);
+});


### PR DESCRIPTION
## Summary

Adds a `review_level` config value — `strict | moderate | lenient`, default `moderate` — that sets how strict the code reviewers are, so a project isn't stuck with one strictness for everyone. Under every level a blocking finding must be *reachable* under that level's trust boundaries, so the reviewer stops treating internal run artifacts like auth boundaries (the behavior that drove a recent run into 17 rounds of forged-inode paranoia).

## The levels

- **strict** — assume adversarial trust boundaries; a hardening gap or missing defense against a local/adversarial actor is reachable and blocks. Roughly today's behavior, now opt-in.
- **moderate** (default) — internal run artifacts aren't security boundaries; block on correctness bugs and failures reachable under normal use; don't require defenses against an actor who could already edit the files. Fixes the out-of-box over-engineering.
- **lenient** — correctness and real, reachable bugs only.

`~/.neal/guidance/reviewer.md` layers free text on top for anything finer. A **fixed floor** at every level and under any guidance keeps the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures always on — so guidance can tune boundaries but never neuter review.

## Changes

- `src/neal/config.ts` — `review_level` key, `getReviewLevel(cwd)` accessor, enum validation that throws on an unknown value naming `neal.review_level`; wired into `neal check`
- `src/neal/prompts/review-doctrine.ts` — `getReviewLevelCalibrationLines(level)`, rendered by both code-review builders after the adversarial doctrine; `getFindingQualityLines` softens the robustness/perf line under `lenient`
- `src/neal/prompts/execute.ts`, `specialized.ts`, `agents/rounds.ts` — thread the resolved level into the scope and final-completion reviewers (builders stay pure)
- Render matrices gain a `reviewLevel` axis; `scope_reviewer`/`completion_reviewer` spec versions bump, goldens appended
- `neal.yml`, docs, CHANGELOG

## Verification

- Full suite green at head: typecheck, lint, 1776 tests, build, verify:package.
- Judgment read of the rendered doctrine per level confirms the calibration (strict blocks the local-process case, moderate doesn't, lenient is correctness-only; reachability filter and fixed floor present at every level).
- The behavioral effect isn't offline-testable (no live provider in CI). A live strict-vs-moderate spot-check on a real diff is operator-owned and can run before or after merge; it doesn't change the code.

Built by a plan-driven neal run; the final-completion reviewer approved the implementation and blocked only for this operator-owned verification.