### PR TITLE
Ignore stray files in the runs directory during neal review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ dependency-update policy.
   terminal directive resolving to `terminal_block` no longer fails to save. The
   terminal directive records one resolution turn past the cap, and the state
   invariant now allows that single extra turn (#37).
+- `neal review` no longer fails with `ENOTDIR` when the runs directory holds a
+  stray file such as macOS `.DS_Store`. Its read-only state check now looks at
+  run directories only.
 
 ## [0.6.0] - 2026-08-25
 

--- a/src/neal/review-findings/run.ts
+++ b/src/neal/review-findings/run.ts
@@ -1,3 +1,4 @@
+import type { Dirent } from 'node:fs';
 import { readdir, readFile } from 'node:fs/promises';
 import { join, normalize, resolve } from 'node:path';
 
@@ -450,9 +451,9 @@ async function readOptionalText(path: string) {
 
 async function readRunStates(cwd: string) {
   const runsDir = getRunsDir(cwd);
-  let entries: string[];
+  let entries: Dirent[];
   try {
-    entries = await readdir(runsDir);
+    entries = await readdir(runsDir, { withFileTypes: true });
   } catch (error) {
     if (isMissingFileError(error)) {
       return {};
@@ -461,7 +462,14 @@ async function readRunStates(cwd: string) {
   }
 
   const states: Record<string, string> = {};
-  for (const entry of entries.sort()) {
+  // Only directories are runs. The runs root also collects stray files such as
+  // macOS `.DS_Store`, and joining a run-state path onto one of those reads
+  // through a non-directory.
+  const runDirNames = entries
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .sort();
+  for (const entry of runDirNames) {
     const statePath = getRunStatePath(join(runsDir, entry));
     const content = await readOptionalText(statePath);
     if (content !== null) {
@@ -484,6 +492,13 @@ function assertSameStringMap(before: Record<string, string>, after: Record<strin
   }
 }
 
+// A run-state path can be unreadable because nothing is there (`ENOENT`) or
+// because a path segment is not a directory (`ENOTDIR`, e.g. a stray file in the
+// runs root). Both mean "no run state here", never a review failure.
 function isMissingFileError(error: unknown) {
-  return typeof error === 'object' && error !== null && 'code' in error && (error as { code?: unknown }).code === 'ENOENT';
+  if (typeof error !== 'object' || error === null || !('code' in error)) {
+    return false;
+  }
+  const code = (error as { code?: unknown }).code;
+  return code === 'ENOENT' || code === 'ENOTDIR';
 }

--- a/test/review-mode.test.ts
+++ b/test/review-mode.test.ts
@@ -350,6 +350,36 @@ test('neal review writes accepted findings artifacts without writer-run mutation
   assert.match(stderr.text(), /review: analyzing 1 commit/);
 });
 
+test('neal review ignores a stray file in the runs directory', async () => {
+  const repo = await createRepo('neal-review-stray-runs-entry-');
+  await repo.commitFile('feature.txt', 'feature\n', 'add feature');
+  await mkdir(join(repo.cwd, '.neal', 'runs', 'writer-run'), { recursive: true });
+  await writeFile(join(repo.cwd, '.neal', 'runs', 'writer-run', 'RUN_STATE.json'), '{"sentinel":"run-state"}\n', 'utf8');
+  // macOS drops .DS_Store into any directory opened in Finder; the runs root is
+  // not exclusively run directories.
+  await writeFile(join(repo.cwd, '.neal', 'runs', '.DS_Store'), 'finder metadata\n', 'utf8');
+
+  const provider = new QueueReviewProvider(
+    [sampleDraft()],
+    [acceptedFinal(['# Review Findings', '', '## Summary', '', 'No findings.'].join('\n'))],
+  );
+  const stdout = new CaptureWritable();
+  const stderr = new CaptureWritable();
+
+  const result = await runNealReviewCli({
+    cwd: repo.cwd,
+    parsed: parseReviewArgs(['review', 'Review this feature commit', '--since', repo.baseCommit]),
+    stdout,
+    stderr,
+    provider,
+    reviewId: 'review-stray-runs-entry',
+    now: new Date('2026-05-17T12:00:00.000Z'),
+  });
+
+  assert.equal(result.outcome, 'accepted');
+  assert.equal(await readFile(join(repo.cwd, '.neal', 'runs', '.DS_Store'), 'utf8'), 'finder metadata\n');
+});
+
 test('neal review records resumable Agent SDK session handles and prints a resume hint', async () => {
   const repo = await createRepo('neal-review-resume-');
   await repo.commitFile('feature.txt', 'feature\n', 'add feature');


### PR DESCRIPTION
## Summary

`neal review` failed outright with `ENOTDIR: not a directory, open '.neal/runs/.DS_Store/RUN_STATE.json'` on any machine where the runs directory picked up a stray file. macOS creates `.DS_Store` in any directory opened in Finder, so this hit real users with an opaque error naming a path that doesn't exist. Found while running a live review during #39 verification.

## Cause

`readRunStates` in `src/neal/review-findings/run.ts` snapshots every run's `RUN_STATE.json` before and after the review to prove the review didn't mutate state. Two flaws combined:

1. It called `readdir(runsDir)` without `{ withFileTypes: true }`, so it couldn't filter directories and treated `.DS_Store` as a run directory. The other two runs-root enumerators (`listRuns` in `run-registry.ts`, `discoverSquashCandidates` in `squash.ts`) both pass `withFileTypes` and filter `isDirectory()`.
2. `isMissingFileError` matched only `ENOENT`, so the resulting `ENOTDIR` was rethrown instead of treated as "no run state here".

## Changes

- `readRunStates` reads with `withFileTypes` and considers directories only, matching the other enumerators
- `isMissingFileError` treats `ENOTDIR` like `ENOENT` — both mean no run state at that path
- Regression test: a `.DS_Store` in `.neal/runs/` no longer fails a review, and the stray file is left untouched

Verified the test fails without the source fix (reproducing the exact production error) and passes with it. Full suite green: typecheck, lint, 1761 tests, build, verify:package.