### PR TITLE
Prepare 0.6.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ dependency-update policy.
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-08-28
+
+### Changed
+
+- Updated `@anthropic-ai/claude-agent-sdk` from `0.3.240` to `0.3.246` and `@openai/codex-sdk` from `0.149.0` to `0.149.1`. Re-qualified both native adapters with `neal compat`; no behavior change.
+
 ### Added
 
 - Operator guidance during a block can revise a later scope. When a

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@navels/neal",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "A source-first multi-agent CLI for planning, executing, reviewing, and resuming scoped code changes.",
   "license": "MIT",
   "publishConfig": {


### PR DESCRIPTION
## Summary

Release prep for 0.6.1, a patch release covering the dependency bumps from #35.

## Changes

- Bump `package.json.version` to 0.6.1
- Add the 0.6.1 changelog section:

- Updated `@anthropic-ai/claude-agent-sdk` from `0.3.240` to `0.3.246` and `@openai/codex-sdk` from `0.149.0` to `0.149.1`. Re-qualified both native adapters with `neal compat`; no behavior change.

All release gates pass locally via scripts/release-sdk-bump.sh.