### PR TITLE
Prepare 0.6.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ dependency-update policy.
 
 ## [Unreleased]
 
+## [0.6.2] - 2026-09-01
+
+### Changed
+
+- Updated `@anthropic-ai/claude-agent-sdk` from `0.3.246` to `0.3.251` and `@openai/codex-sdk` from `0.149.1` to `0.151.0`. Re-qualified both native adapters with `neal compat`; no behavior change.
+
 ## [0.6.1] - 2026-08-28
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@navels/neal",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "A source-first multi-agent CLI for planning, executing, reviewing, and resuming scoped code changes.",
   "license": "MIT",
   "publishConfig": {


### PR DESCRIPTION
## Summary

Release prep for 0.6.2, a patch release covering the dependency bumps from #42.

## Changes

- Bump `package.json.version` to 0.6.2
- Add the 0.6.2 changelog section:

- Updated `@anthropic-ai/claude-agent-sdk` from `0.3.246` to `0.3.251` and `@openai/codex-sdk` from `0.149.1` to `0.151.0`. Re-qualified both native adapters with `neal compat`; no behavior change.

All release gates pass locally via scripts/release-sdk-bump.sh.