### PR TITLE
Prepare 0.6.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ dependency-update policy.
 
 ## [Unreleased]
 
+## [0.6.3] - 2026-09-03
+
+### Changed
+
+- Updated `@anthropic-ai/claude-agent-sdk` from `0.3.251` to `0.3.252`. Re-qualified the native adapter with `neal compat`; no behavior change.
+
 ## [0.6.2] - 2026-09-01
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@navels/neal",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "A source-first multi-agent CLI for planning, executing, reviewing, and resuming scoped code changes.",
   "license": "MIT",
   "publishConfig": {


### PR DESCRIPTION
## Summary

Release prep for 0.6.3, a patch release covering the dependency bumps from #45.

## Changes

- Bump `package.json.version` to 0.6.3
- Add the 0.6.3 changelog section:

- Updated `@anthropic-ai/claude-agent-sdk` from `0.3.251` to `0.3.252`. Re-qualified the native adapter with `neal compat`; no behavior change.

All release gates pass locally via scripts/release-sdk-bump.sh.