### PR TITLE
Poll the npm registry while a publish propagates during finalize

### DIFF
--- a/scripts/finalize-release.mjs
+++ b/scripts/finalize-release.mjs
@@ -9,6 +9,7 @@ import {
   getChangelogSection,
   parseProvenanceStatement,
   parseRemoteTagTarget,
+  retryWhilePropagating,
 } from './release-utils.mjs';
 
 const rootDir = resolve(dirname(fileURLToPath(import.meta.url)), '..');
@@ -80,10 +81,15 @@ assert(repositorySlug === 'navels/neal', `Expected GITHUB_REPOSITORY navels/neal
 assert(process.env.GITHUB_REF === 'refs/heads/main', `Expected GITHUB_REF refs/heads/main; got ${process.env.GITHUB_REF ?? 'unset'}.`);
 assert(process.env.GH_TOKEN, 'GH_TOKEN is required.');
 
-run('npm', ['view', `${packageName}@${version}`, 'version', '--json']);
-await verifySignedAttestations();
+await retryWhilePropagating(`${packageName}@${version}`, () =>
+  run('npm', ['view', `${packageName}@${version}`, 'version', '--json']),
+);
+await retryWhilePropagating(`Signed attestations for ${packageName}@${version}`, () => verifySignedAttestations());
 
-const attestationResponse = await fetchProvenance();
+const attestationResponse = await retryWhilePropagating(
+  `Provenance attestation for ${packageName}@${version}`,
+  () => fetchProvenance(),
+);
 const statement = parseProvenanceStatement(attestationResponse);
 assertReleaseProvenance(statement, {
   packageName,

--- a/scripts/release-utils.mjs
+++ b/scripts/release-utils.mjs
@@ -1,7 +1,42 @@
 const provenancePredicateType = 'https://slsa.dev/provenance/v1';
 
+// npm's read replicas lag a publish: for a short window after a staged package
+// goes public, the version and its attestations can still read as 404. The
+// finalize step runs immediately after approval, so it polls through that
+// window instead of failing the release.
+export const REGISTRY_PROPAGATION_TIMEOUT_MS = 5 * 60_000;
+export const REGISTRY_PROPAGATION_INTERVAL_MS = 10_000;
+
 function fail(message) {
   throw new Error(message);
+}
+
+// A 404 from the registry right after publish means "not propagated yet". Any
+// other failure (auth, provenance mismatch, signature mismatch) is real and must
+// not be retried.
+export function isRegistryPropagationError(error) {
+  return /\b(?:E404|404)\b/.test(String(error?.message ?? ''));
+}
+
+export async function retryWhilePropagating(label, attempt, options = {}) {
+  const timeoutMs = options.timeoutMs ?? REGISTRY_PROPAGATION_TIMEOUT_MS;
+  const intervalMs = options.intervalMs ?? REGISTRY_PROPAGATION_INTERVAL_MS;
+  const now = options.now ?? (() => Date.now());
+  const sleep = options.sleep ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
+  const log = options.log ?? ((message) => console.log(message));
+  const deadline = now() + timeoutMs;
+
+  for (let attemptNumber = 1; ; attemptNumber += 1) {
+    try {
+      return await attempt();
+    } catch (error) {
+      if (!isRegistryPropagationError(error) || now() >= deadline) {
+        throw error;
+      }
+      log(`${label} is not visible in the npm registry yet (attempt ${attemptNumber}); retrying in ${Math.round(intervalMs / 1000)}s.`);
+      await sleep(intervalMs);
+    }
+  }
 }
 
 export function getChangelogSection(markdown, version) {

--- a/test/release-utils.test.ts
+++ b/test/release-utils.test.ts
@@ -26,6 +26,18 @@ type ReleaseUtilsModule = {
     tagExists: boolean;
     version: string;
   }) => void;
+  isRegistryPropagationError: (error: unknown) => boolean;
+  retryWhilePropagating: <T>(
+    label: string,
+    attempt: () => T | Promise<T>,
+    options?: {
+      timeoutMs?: number;
+      intervalMs?: number;
+      now?: () => number;
+      sleep?: (ms: number) => Promise<void>;
+      log?: (message: string) => void;
+    },
+  ) => Promise<T>;
 };
 
 const releaseUtils = await import(
@@ -161,4 +173,81 @@ test('release-state recovery is allowed only on the real-publish path', () => {
     }),
     /Remote tag v0\.3\.1 already exists/,
   );
+});
+
+test('isRegistryPropagationError matches only registry 404s', () => {
+  assert.equal(releaseUtils.isRegistryPropagationError(new Error('npm error code E404')), true);
+  assert.equal(releaseUtils.isRegistryPropagationError(new Error('Unable to fetch npm attestations: HTTP 404.')), true);
+  assert.equal(releaseUtils.isRegistryPropagationError(new Error('npm error code E403 Forbidden')), false);
+  assert.equal(releaseUtils.isRegistryPropagationError(new Error('provenance commit mismatch')), false);
+  assert.equal(releaseUtils.isRegistryPropagationError(undefined), false);
+});
+
+test('retryWhilePropagating polls a lagging registry read until it succeeds', async () => {
+  const sleeps: number[] = [];
+  let calls = 0;
+  const result = await releaseUtils.retryWhilePropagating(
+    '@navels/neal@0.3.1',
+    () => {
+      calls += 1;
+      if (calls < 3) {
+        throw new Error('npm error code E404\nnpm error 404 No match found for version 0.3.1');
+      }
+      return 'visible';
+    },
+    {
+      intervalMs: 10_000,
+      sleep: async (ms: number) => {
+        sleeps.push(ms);
+      },
+      log: () => {},
+    },
+  );
+
+  assert.equal(result, 'visible');
+  assert.equal(calls, 3);
+  assert.deepEqual(sleeps, [10_000, 10_000]);
+});
+
+test('retryWhilePropagating rethrows a real failure without polling', async () => {
+  let calls = 0;
+  await assert.rejects(
+    () =>
+      releaseUtils.retryWhilePropagating(
+        'signed attestations',
+        () => {
+          calls += 1;
+          throw new Error('npm error code EINTEGRITY signature mismatch');
+        },
+        { sleep: async () => {}, log: () => {} },
+      ),
+    /EINTEGRITY/,
+  );
+  assert.equal(calls, 1, 'a non-propagation failure must fail the release immediately');
+});
+
+test('retryWhilePropagating gives up once the propagation window closes', async () => {
+  let clock = 0;
+  let calls = 0;
+  await assert.rejects(
+    () =>
+      releaseUtils.retryWhilePropagating(
+        '@navels/neal@0.3.1',
+        () => {
+          calls += 1;
+          throw new Error('npm error code E404');
+        },
+        {
+          timeoutMs: 30_000,
+          intervalMs: 10_000,
+          now: () => clock,
+          sleep: async (ms: number) => {
+            clock += ms;
+          },
+          log: () => {},
+        },
+      ),
+    /E404/,
+  );
+  assert.equal(calls, 4, 'polls through the window, then surfaces the registry error');
 });


### PR DESCRIPTION
## Summary

The Publish workflow has now failed twice (0.5.0 and 0.6.3) *after* a successful npm approval: the package goes public, then `finalize-release.mjs` immediately reads it back and npm's read replicas haven't caught up, so `npm view @navels/neal@<version>` returns `E404` and the run dies before creating the tag and GitHub release. Both times the recovery was to rerun Publish by hand once propagation caught up.

## Fix

`finalize-release.mjs` now polls through the propagation window instead of failing on the first 404. Three registry-dependent steps are wrapped: the version presence check, the signed-attestation verification, and the provenance fetch — all three read back something that was just published.

Only a 404 is retried (`isRegistryPropagationError`). Any real failure — auth, provenance mismatch, signature mismatch — still fails the release immediately, so the release gates keep their teeth. The window is 5 minutes, polled every 10 seconds.

## Changes

- `scripts/release-utils.mjs`: `isRegistryPropagationError` and `retryWhilePropagating` (injectable clock/sleep so the retry logic is testable)
- `scripts/finalize-release.mjs`: wrap the presence check, attestation verification, and provenance fetch
- `test/release-utils.test.ts`: four tests — the predicate matches only registry 404s; a lagging read polls until it succeeds; a non-404 failure rethrows without polling; the poll gives up when the window closes

Full suite green: typecheck, lint, 1782 tests, build, verify:package.