### PR TITLE
Keep the planner's reason when a plan-mode run blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ dependency-update policy.
 
 ## [Unreleased]
 
+### Fixed
+
+- A planner block during `neal plan` no longer loses its reason. The planner's
+  explanation is saved with the run and shown on the console, in the run result,
+  and in `neal status`. The run result's next step now says a plain `neal resume`
+  re-runs the planner when that's what the block needs, instead of the generic
+  `--message` hint (#49).
+
 ## [0.6.3] - 2026-09-03
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,9 @@ dependency-update policy.
   explanation is saved with the run and shown on the console, in the run result,
   and in `neal status`. The run result's next step now says a plain `neal resume`
   re-runs the planner when that's what the block needs, instead of the generic
-  `--message` hint (#49).
+  `--message` hint. A crashed round (a provider error or timeout) now prints its
+  error on the console too, instead of a bare "Run failed."; `neal status`
+  already showed it (#49).
 
 ## [0.6.3] - 2026-09-03
 

--- a/src/neal/agents/rounds.ts
+++ b/src/neal/agents/rounds.ts
@@ -771,7 +771,7 @@ export async function runCoderPlanRound(args: {
   // instructing the refiner to keep it single-scope.
   authoredOneShot?: boolean;
   logger?: RunLogger;
-}): Promise<{ sessionHandle: string | null; finalResponse: string; marker: string | null }> {
+}): Promise<{ sessionHandle: string | null; finalResponse: string; marker: string | null; blockedReason: string | null }> {
   if (args.sessionHandle && args.coderSessionProtocol === null) {
     throw new Error('Cannot resume planner planning session without plannerSessionProtocol.');
   }
@@ -815,6 +815,7 @@ export async function runCoderPlanRound(args: {
       sessionHandle,
       finalResponse,
       marker,
+      blockedReason: normalizedPayload.action === 'blocked' ? normalizedPayload.blockedReason.trim() || null : null,
     };
   }
 
@@ -864,6 +865,7 @@ export async function runCoderPlanRound(args: {
     sessionHandle,
     finalResponse,
     marker,
+    blockedReason: null,
   };
 }
 

--- a/src/neal/commands/runtime.ts
+++ b/src/neal/commands/runtime.ts
@@ -26,6 +26,7 @@ import {
   isPlanRefinementState,
 } from '../plan-refinement.js';
 import { acquireActiveRunLock, releaseActiveRunLockSync, type ActiveRunLockHandle } from '../run-lock.js';
+import { planResumeActions } from '../resume-planner.js';
 import { formatPublicRunStatus, getRunDisplayStatus, type RunDisplayStatus } from '../run-status.js';
 import { getCurrentScopeLabel } from '../scopes.js';
 import { resolveRunStatePath, type RunStatePathSource } from '../run-registry.js';
@@ -368,6 +369,9 @@ function formatFinalNextAction(
     return `Inspect failure: neal status --run ${runId}; resume when ready: neal resume --run ${runId}`;
   }
   if (finalState.status === 'blocked') {
+    if (planResumeActions(finalState).some((action) => action.kind === 'restore_resumable_blocked_phase')) {
+      return `Address the reason above, then re-run ${formatPublicPhase(finalState.blockedFromPhase ?? finalState.phase)}: neal resume --run ${runId}`;
+    }
     return `Inspect blocked run: neal status --run ${runId}; provide guidance with neal resume --run ${runId} --message "..." only if the run is waiting for operator guidance`;
   }
   if (displayStatus.effectiveStatus === 'paused') {
@@ -442,6 +446,10 @@ export function renderFinalRunOutput(
   });
   if (guidance) {
     lines.push('', ...renderBlockedGuidanceSections(guidance));
+  } else if (finalState.blockerReason) {
+    // A block that is not waiting for `--message` guidance has no guidance
+    // section, so print the stored reason under the same heading.
+    lines.push('', '## Why Neal Stopped', finalState.blockerReason);
   }
 
   lines.push('', '## Next Action', `- ${formatFinalNextAction(finalState, displayStatus, runId, guidance)}`);

--- a/src/neal/commands/runtime.ts
+++ b/src/neal/commands/runtime.ts
@@ -301,6 +301,13 @@ function armShutdownWatchdog(finalState: OrchestrationState, logger: RunLogger) 
   };
 }
 
+// Keep a crash message readable on the console; `neal status` carries the
+// full text from the `phase.error` event.
+function truncateFailureMessage(message: string) {
+  const trimmed = message.trim();
+  return trimmed.length > 1000 ? `${trimmed.slice(0, 1000)}…` : trimmed;
+}
+
 function formatFinalSummaryLine(finalState: OrchestrationState, publicStatus: string) {
   if (publicStatus === 'waiting_for_manual_gate') {
     const gate = finalState.manualGate;
@@ -388,6 +395,7 @@ export function renderFinalRunOutput(
   statePath: string,
   displayStatus: RunDisplayStatus,
   autoSquashResult: ExecutedSquashResult | null = null,
+  failureMessage: string | null = null,
 ) {
   const runId = basename(finalState.runDir);
   const publicStatus = formatPublicRunStatus(displayStatus);
@@ -450,6 +458,12 @@ export function renderFinalRunOutput(
     // A block that is not waiting for `--message` guidance has no guidance
     // section, so print the stored reason under the same heading.
     lines.push('', '## Why Neal Stopped', finalState.blockerReason);
+  } else if (finalState.status === 'failed' && failureMessage) {
+    // A crashed round is caught above and rendered as a failed result instead
+    // of being rethrown, so the error text has to be printed here or the
+    // console never shows it. `neal status` reads the same message from the
+    // `phase.error` event.
+    lines.push('', '## Why Neal Stopped', truncateFailureMessage(failureMessage));
   }
 
   lines.push('', '## Next Action', `- ${formatFinalNextAction(finalState, displayStatus, runId, guidance)}`);
@@ -570,6 +584,7 @@ export async function executeRun(
     }
 
     let finalState;
+    let runFailureMessage: string | null = null;
     try {
       try {
         finalState = await runOnePass(state, statePath, logger, {
@@ -593,6 +608,7 @@ export async function executeRun(
         if (!finalState) {
           throw error;
         }
+        runFailureMessage = error instanceof Error ? error.message : String(error);
       }
     } finally {
       stopController.cleanup();
@@ -641,7 +657,7 @@ export async function executeRun(
       runDir: finalState.runDir,
     });
 
-    const finalOutput = renderFinalRunOutput(finalState, statePath, displayStatus, autoSquashResult);
+    const finalOutput = renderFinalRunOutput(finalState, statePath, displayStatus, autoSquashResult, runFailureMessage);
     process.stdout.write(finalOutput.trimEnd() + '\n');
 
     await logger.event('shutdown.final_output_written', {

--- a/src/neal/orchestrator/phases/planning.ts
+++ b/src/neal/orchestrator/phases/planning.ts
@@ -305,18 +305,24 @@ export async function runCoderPlanPhase(state: OrchestrationState, statePath: st
   }
   const completionProblem = getPlanningCompletionProblem(codex.marker);
   const dirtyWorktreeBlocker = await getPlanPhaseDirtyWorktreeBlocker(workingState, 'coder_plan');
+  const blocked = codex.marker === 'AUTONOMY_BLOCKED' || Boolean(completionProblem) || Boolean(dirtyWorktreeBlocker);
+  // Persist why the planner stopped so `neal status` and the run result can show
+  // it. A `coder_plan` block is never answerable via `neal resume --message`
+  // (that eligibility keys on `blockedFromPhase`), so a non-null reason here
+  // only informs the operator; it does not change resume behavior.
+  const reason = blocked
+    ? dirtyWorktreeBlocker ?? completionProblem ?? codex.blockedReason ?? 'The planner reported a blocker during plan refinement'
+    : null;
 
   const nextState = await saveState(statePath, {
     ...workingState,
     plannerSessionHandle: codex.sessionHandle,
     plannerSessionProtocol: codex.sessionHandle ? activePlannerSessionProtocol : null,
     lastScopeMarker: codex.marker as ScopeMarker | null,
-    phase: codex.marker === 'AUTONOMY_BLOCKED' || completionProblem || dirtyWorktreeBlocker ? 'blocked' : 'reviewer_plan',
-    status: codex.marker === 'AUTONOMY_BLOCKED' || completionProblem || dirtyWorktreeBlocker ? 'blocked' : 'running',
-    blockedFromPhase: codex.marker === 'AUTONOMY_BLOCKED' || completionProblem || dirtyWorktreeBlocker ? 'coder_plan' : null,
-    // The initial coder_plan authoring block never carries the recoverable
-    // coder-response blocker reason; keep it cleared whether we advance or block.
-    blockerReason: null,
+    phase: blocked ? 'blocked' : 'reviewer_plan',
+    status: blocked ? 'blocked' : 'running',
+    blockedFromPhase: blocked ? 'coder_plan' : null,
+    blockerReason: reason,
   });
 
   await writeExecutionArtifacts(nextState);
@@ -326,8 +332,7 @@ export async function runCoderPlanPhase(state: OrchestrationState, statePath: st
     sessionHandle: codex.sessionHandle,
     nextPhase: nextState.phase,
   });
-  if (nextState.status === 'blocked') {
-    const reason = dirtyWorktreeBlocker ?? completionProblem ?? 'The coder reported a blocker during plan revision';
+  if (nextState.status === 'blocked' && reason !== null) {
     if (nextState.topLevelMode !== 'execute') {
       await notifyBlocked(nextState, reason, logger);
       return nextState;

--- a/src/neal/terminal-narrator.ts
+++ b/src/neal/terminal-narrator.ts
@@ -425,14 +425,16 @@ function renderLifecycleEvents(
 
   if (state.status === 'blocked') {
     const blockedPhase = state.blockedFromPhase ?? state.phase;
+    const blockLine = formatScopeRelatedPhase(blockedPhase)
+      ? options.scopeIntroEstablished
+        ? `Run is blocked during ${formatPublicPhase(blockedPhase)}.`
+        : `Run is blocked during ${formatPublicPhase(blockedPhase)} for ${scopeReference}.`
+      : `Run is blocked during ${formatPublicPhase(blockedPhase)}.`;
+    const reason = (state.blockerReason ?? state.interactiveBlockedRecovery?.blockedReason ?? '').replace(/\s+/g, ' ').trim();
     return [
       {
         signature: `lifecycle:${runId}:blocked:${blockedPhase}`,
-        line: formatScopeRelatedPhase(blockedPhase)
-          ? options.scopeIntroEstablished
-            ? `Run is blocked during ${formatPublicPhase(blockedPhase)}.`
-            : `Run is blocked during ${formatPublicPhase(blockedPhase)} for ${scopeReference}.`
-          : `Run is blocked during ${formatPublicPhase(blockedPhase)}.`,
+        line: reason ? `${blockLine} ${reason}` : blockLine,
       },
     ];
   }

--- a/test/orchestrator-planning.test.ts
+++ b/test/orchestrator-planning.test.ts
@@ -377,7 +377,60 @@ test('runCoderPlanPhase blocks when planner dirties non-plan files', async () =>
     assert.equal(nextState.blockedFromPhase, 'coder_plan');
     assert.equal(persisted.phase, 'blocked');
     assert.equal(nextState.interactiveBlockedRecovery, null);
+    assert.match(persisted.blockerReason ?? '', /worktree|dirty|non-plan/i);
     assert.match(await runGit(cwd, 'status', '--short'), /src\.ts/);
+  } finally {
+    clearProviderCapabilitiesOverridesForTesting();
+  }
+});
+
+test('runCoderPlanPhase persists the planner\'s reason when it blocks and the run stays resumable', async () => {
+  const { cwd, statePath, state } = await createResumeFixture({
+    topLevelMode: 'plan',
+    phase: 'coder_plan',
+    status: 'running',
+    blockedFromPhase: null,
+  });
+  const blockedReason = 'The plan asks for a Postgres migration but this repository has no database layer to migrate.';
+
+  setProviderCapabilitiesOverrideForTesting('openai-codex', {
+    createCoderAdapter() {
+      return {
+        async runPrompt(args: CoderRunPromptArgs) {
+          throw new Error(`unexpected text planning prompt: ${args.prompt}`);
+        },
+        async runStructuredPrompt<TStructured>() {
+          return {
+            sessionHandle: 'planner-blocked-session',
+            structured: {
+              action: 'blocked',
+              message: 'Cannot refine this plan as written.',
+              executionShape: 'one_shot',
+              planBody: '',
+              blockedReason,
+            } as TStructured,
+          };
+        },
+      };
+    },
+  });
+
+  try {
+    const nextState = await runCoderPlanPhase(state, statePath);
+    const persisted = await loadState(statePath);
+
+    assert.equal(nextState.status, 'blocked');
+    assert.equal(nextState.blockedFromPhase, 'coder_plan');
+    assert.equal(persisted.blockerReason, blockedReason);
+
+    // A plain `neal resume` re-runs the planner; the block is not a `--message` block.
+    assert.equal(getPlanReviewGuidanceOriginPhase(persisted), null);
+    assert.ok(planResumeActions(persisted).some((action) => action.kind === 'restore_resumable_blocked_phase'));
+
+    const snapshot = await buildStatusSnapshot({ cwd, statePath, now: new Date() });
+    assert.equal(snapshot.blocker.reason, blockedReason);
+    assert.equal(snapshot.blocker.source, 'RUN_STATE.json blocker reason');
+    assert.match(renderHumanStatusSnapshot(snapshot), /Postgres migration/);
   } finally {
     clearProviderCapabilitiesOverridesForTesting();
   }

--- a/test/provider-diagnostics.test.ts
+++ b/test/provider-diagnostics.test.ts
@@ -389,6 +389,22 @@ test('final run output is compact and points to the retrospective artifact', asy
   assert.doesNotMatch(output, /This detailed retrospective should stay in the artifact/);
 });
 
+test('final run output prints the crash message so the console says why the run failed', async () => {
+  const { state, statePath } = await createState({
+    phase: 'coder_scope',
+    status: 'failed',
+  });
+  const failureMessage = 'Coder scope round failed: provider returned 503 Service Unavailable after 3 retries.';
+
+  const output = renderFinalRunOutput(state, statePath, getRunDisplayStatus(state), null, failureMessage);
+
+  assert.match(output, /## Why Neal Stopped/);
+  assert.match(output, /provider returned 503 Service Unavailable after 3 retries/);
+
+  const silent = renderFinalRunOutput(state, statePath, getRunDisplayStatus(state));
+  assert.doesNotMatch(silent, /## Why Neal Stopped/);
+});
+
 test('final run output directs failed runs to status and resume', async () => {
   const { state, statePath } = await createState({
     phase: 'coder_scope',


### PR DESCRIPTION
## Summary

Fixes #49. When the planner blocked during `neal plan`, neal threw its explanation away and saved the run as just "blocked", so the console, the run result, and `neal status` all showed a bare "Run is blocked" and the only copy of the reason was a line in `stderr.log`. The reporter ended up hand-editing `RUN_STATE.json` to get unstuck, which they didn't need to do: a plain `neal resume` re-runs the planner for this kind of block, but the hint never said so.

The same report covered crashes ("failures, blocks, etc."). A crashed round (provider error, timeout) is caught and rendered as a failed result instead of being rethrown, so the console printed "Run failed." with no error text. `neal status` already showed it from the `phase.error` event; the console didn't.

## Cause

- The planner's blocked payload must carry a `blockedReason` (the validator rejects one without it), but `runCoderPlanRound` returned only the marker and dropped it.
- `planning.ts` then substituted a canned sentence and saved `blockerReason: null` on purpose. In plan mode that sentence only went to the notification hook and was never stored.
- The run result only prints a reason for blocks that take `--message`, and the narrator's block line never read one at all.
- For crashes, `runtime.ts` catches the thrown error, loads the persisted failed state, and continues to the run result, so nothing upstream ever prints the message.

Storing the block reason in `blockerReason` is safe: `--message` eligibility keys on `blockedFromPhase` first and `coder_plan` isn't in the answerable set, so this changes what the operator sees and nothing about resume.

## Changes

- `rounds.ts`: `runCoderPlanRound` returns the planner's `blockedReason` (null on the free-text protocol, which has no structured reason)
- `planning.ts`: persist the block reason (dirty-worktree or completion problem first, then the planner's reason, then a fallback); null when the run advances
- `runtime.ts`: the run result prints the stored block reason, or the caught crash message, under "Why Neal Stopped" when there's no `--message` guidance section; the next-step line says `neal resume` re-runs the blocked phase when `planResumeActions` reports it's resumable
- `terminal-narrator.ts`: the "Run is blocked during …" line carries the reason (planner block or interactive-recovery block)
- Tests: a planner block persists its reason, is not a `--message` block, is resumable by plain `neal resume`, and shows the reason in `neal status`; the dirty-worktree block test also checks its reason persists; a failed run's result prints the crash message and omits the section when there is none

Verified the planner-block test fails without the source change and passes with it. Full suite green: typecheck, lint, 1780 tests, build, verify:package.