### PR TITLE
Prepare 0.6.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ dependency-update policy.
 
 ## [Unreleased]
 
+## [0.6.4] - 2026-09-04
+
 ### Fixed
 
 - A planner block during `neal plan` no longer loses its reason. The planner's

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@navels/neal",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "A source-first multi-agent CLI for planning, executing, reviewing, and resuming scoped code changes.",
   "license": "MIT",
   "publishConfig": {


### PR DESCRIPTION
## Summary

Release prep for 0.6.4, a patch with the #49 fixes.

## Changes

- `package.json` version 0.6.3 → 0.6.4
- `CHANGELOG.md`: move the Unreleased entry under `## [0.6.4] - 2026-09-04`