### PR TITLE
Make the manual SDK-bump path work end to end

### DIFF
--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -53,8 +53,8 @@ is gated on it as a whole.
    runs the Publish workflow through the npm 2FA approval. See
    [docs/release.md](release.md). Urgent bumps (a fix neal needs immediately)
    may skip the Renovate soak with a manual PR: `scripts/bump-native-sdks.sh`
-   opens one at the current latest releases and closes Renovate's SDK PR as
-   superseded. Qualify it the same way.
+   opens one at the current latest releases. Qualify it the same way. Leave
+   Renovate's own SDK PR open; it closes itself once the manual bump merges.
 
 ## TypeScript 6 and 7 side by side
 

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -52,7 +52,9 @@ is gated on it as a whole.
    opens and merges the release-preparation PR (version bump + changelog), and
    runs the Publish workflow through the npm 2FA approval. See
    [docs/release.md](release.md). Urgent bumps (a fix neal needs immediately)
-   may skip the Renovate soak with a manual PR. Qualify them the same way.
+   may skip the Renovate soak with a manual PR: `scripts/bump-native-sdks.sh`
+   opens one at the current latest releases and closes Renovate's SDK PR as
+   superseded. Qualify it the same way.
 
 ## TypeScript 6 and 7 side by side
 

--- a/scripts/bump-native-sdks.sh
+++ b/scripts/bump-native-sdks.sh
@@ -9,8 +9,10 @@
 # dashboard can tick past that filter. When neal needs a fix today, the
 # sanctioned route is a manual PR; this script is that PR. It resolves each
 # package's `latest` dist-tag (so a prerelease is never picked), rewrites the
-# two exact pins, refreshes the lockfile, pushes a branch, opens the PR, and
-# closes an open Renovate SDK PR as superseded so the two don't compete.
+# two exact pins, refreshes the lockfile, pushes a branch, and opens the PR.
+# Leave Renovate's own SDK PR alone: closing it just makes Renovate re-open
+# it, and once this PR merges Renovate closes its PR itself as no longer
+# needed.
 #
 # Usage: scripts/bump-native-sdks.sh
 #
@@ -86,12 +88,6 @@ ${CHANGE_LINES}
 Qualify before merge: \`scripts/qualify-sdk.sh <this PR>\`. Release with \`scripts/release-sdk-bump.sh <this PR>\`."
 PR_URL="$(gh pr create --title "Update native agentic SDKs" --body "$BODY" --base main --head "$BRANCH")"
 PR="${PR_URL##*/}"
-
-RENOVATE_PR="$(gh pr list --state open --head renovate/native-agentic-sdks --json number --jq '.[0].number // empty')"
-if [ -n "$RENOVATE_PR" ]; then
-  gh pr close "$RENOVATE_PR" --comment "Superseded by #${PR}, which bumps both SDKs to the current latest ahead of the soak." >/dev/null
-  echo "bump-native-sdks: closed Renovate PR #${RENOVATE_PR} as superseded"
-fi
 
 echo "Opened ${PR_URL}"
 echo "Qualify before merge: scripts/qualify-sdk.sh ${PR}"

--- a/scripts/bump-native-sdks.sh
+++ b/scripts/bump-native-sdks.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+#
+# scripts/bump-native-sdks.sh — open a PR that bumps the native agentic SDKs
+# (@openai/codex-sdk, @anthropic-ai/claude-agent-sdk) to their current latest
+# releases, ahead of Renovate.
+#
+# Renovate's native-SDK bucket waits out a 3-day soak (minimumReleaseAge in
+# renovate.json) before it proposes a version, and nothing on the dependency
+# dashboard can tick past that filter. When neal needs a fix today, the
+# sanctioned route is a manual PR; this script is that PR. It resolves each
+# package's `latest` dist-tag (so a prerelease is never picked), rewrites the
+# two exact pins, refreshes the lockfile, pushes a branch, opens the PR, and
+# closes an open Renovate SDK PR as superseded so the two don't compete.
+#
+# Usage: scripts/bump-native-sdks.sh
+#
+# The PR still needs qualification before merge:
+#   scripts/qualify-sdk.sh <pr-number>
+# and is released with scripts/release-sdk-bump.sh <pr-number>.
+#
+# Requirements: gh (authenticated), git, node, npm, pnpm on PATH. Runs in a
+# throwaway git worktree — this checkout's branch, node_modules, and dist are
+# not touched.
+
+set -euo pipefail
+
+for tool in gh git node npm pnpm; do
+  command -v "$tool" >/dev/null 2>&1 || { echo "bump-native-sdks: missing required tool: $tool" >&2; exit 1; }
+done
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SDKS=("@anthropic-ai/claude-agent-sdk" "@openai/codex-sdk")
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/neal-bump-sdks-XXXXXX")"
+BRANCH="bump-native-sdks-$(date -u +%Y%m%d-%H%M%S)"
+cleanup() {
+  git -C "$REPO_ROOT" worktree remove --force "$WORK" >/dev/null 2>&1 || true
+  git -C "$REPO_ROOT" branch -D "$BRANCH" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+git -C "$REPO_ROOT" fetch origin main --quiet
+git -C "$REPO_ROOT" worktree add --quiet -b "$BRANCH" "$WORK" origin/main
+cd "$WORK"
+
+# `npm view <pkg> version` is the `latest` dist-tag, which never points at a
+# prerelease.
+CHANGES=()
+for pkg in "${SDKS[@]}"; do
+  current="$(node -p "require('./package.json').dependencies['$pkg']")"
+  latest="$(npm view "$pkg" version)"
+  if [ "$current" = "$latest" ]; then
+    echo "bump-native-sdks: $pkg already at $latest"
+    continue
+  fi
+  node -e "
+    const fs = require('fs');
+    const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+    pkg.dependencies['$pkg'] = '$latest';
+    fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+  "
+  CHANGES+=("- \`$pkg\` \`$current\` → \`$latest\`")
+  echo "bump-native-sdks: $pkg $current -> $latest"
+done
+
+if [ "${#CHANGES[@]}" -eq 0 ]; then
+  echo "bump-native-sdks: both SDKs are already at their latest release; nothing to do."
+  exit 0
+fi
+
+pnpm install --lockfile-only --loglevel silent
+git add package.json pnpm-lock.yaml
+git commit --quiet -m "Update native agentic SDKs to the latest releases"
+git push --quiet -u origin "$BRANCH"
+
+CHANGE_LINES="$(printf '%s\n' "${CHANGES[@]}")"
+BODY="## Summary
+
+Manual bump of the native agentic SDKs to their current latest releases, ahead of the Renovate soak (see docs/maintenance.md).
+
+## Changes
+
+${CHANGE_LINES}
+- \`pnpm-lock.yaml\` refreshed
+
+Qualify before merge: \`scripts/qualify-sdk.sh <this PR>\`. Release with \`scripts/release-sdk-bump.sh <this PR>\`."
+PR_URL="$(gh pr create --title "Update native agentic SDKs" --body "$BODY" --base main --head "$BRANCH")"
+PR="${PR_URL##*/}"
+
+RENOVATE_PR="$(gh pr list --state open --head renovate/native-agentic-sdks --json number --jq '.[0].number // empty')"
+if [ -n "$RENOVATE_PR" ]; then
+  gh pr close "$RENOVATE_PR" --comment "Superseded by #${PR}, which bumps both SDKs to the current latest ahead of the soak." >/dev/null
+  echo "bump-native-sdks: closed Renovate PR #${RENOVATE_PR} as superseded"
+fi
+
+echo "Opened ${PR_URL}"
+echo "Qualify before merge: scripts/qualify-sdk.sh ${PR}"

--- a/scripts/qualify-sdk.sh
+++ b/scripts/qualify-sdk.sh
@@ -7,8 +7,11 @@
 # adapters (they need subscription auth), so this script runs the missing
 # layer locally: the full test suite plus a live `neal compat --role all`
 # pass-through on the bumped adapter, using the Claude/Codex CLI auth already
-# present on this machine. On PASS it posts the compat matrix to the PR and
-# approves it; on FAIL it posts the evidence and leaves the PR open.
+# present on this machine. On PASS it posts the compat matrix to the PR as an
+# approving review, or as a comment review when the PR is your own (GitHub
+# won't let you approve your own PR; a manual bump from
+# scripts/bump-native-sdks.sh is one of those). On FAIL it posts the evidence
+# and leaves the PR open.
 #
 # Usage: scripts/qualify-sdk.sh <pr-number>
 #
@@ -121,8 +124,16 @@ done
 if [ "$PASS" = "true" ]; then
   BODY="$(printf '**SDK qualification: PASS** — %s.\n\nFull test suite green locally, and \`neal compat --role all\` passed on a subscription-authenticated machine for every bumped adapter.\n\n<details><summary>compat matrices</summary>\n\n%s\n\n</details>' \
     "$QUALIFIED" "$MATRIX")"
-  gh pr review "$PR" --approve --body "$BODY"
-  echo "PASS — approved PR #${PR}."
+  # GitHub rejects an approving review from the PR's own author, so a
+  # self-authored PR gets the same body as a comment review. release-sdk-bump.sh
+  # keys on the "SDK qualification: PASS" marker, not the review state.
+  if [ "$(gh pr view "$PR" --json author --jq .author.login)" = "$(gh api user --jq .login)" ]; then
+    gh pr review "$PR" --comment --body "$BODY"
+    echo "PASS — recorded on PR #${PR} (comment review; you can't approve your own PR)."
+  else
+    gh pr review "$PR" --approve --body "$BODY"
+    echo "PASS — approved PR #${PR}."
+  fi
   echo "Release when ready: scripts/release-sdk-bump.sh ${PR}"
   echo "(merges the PR and runs the full release; or merge only: gh pr merge ${PR} --squash)"
 else

--- a/scripts/release-sdk-bump.sh
+++ b/scripts/release-sdk-bump.sh
@@ -102,11 +102,13 @@ DEP_CHANGES="$(node -e "
 " "$BASE_PKG" "$HEAD_PKG")"
 
 # --- native bumps need a qualify-sdk.sh PASS review ---
+# The marker is the signal, not the review state: qualify-sdk.sh approves a
+# bot-authored PR but can only comment on one you authored yourself.
 NATIVE_COUNT="$(grep -cE '^runtime\|(@openai/codex-sdk|@anthropic-ai/claude-agent-sdk)\|' <<<"$DEP_CHANGES" || true)"
 if [ "$NATIVE_COUNT" -gt 0 ]; then
   QUALIFIED="$(node -pe "
     JSON.parse(process.argv[1]).reviews.some(
-      (r) => r.state === 'APPROVED' && r.body.includes('SDK qualification: PASS'),
+      (r) => (r.state === 'APPROVED' || r.state === 'COMMENTED') && r.body.includes('SDK qualification: PASS'),
     )
   " "$PR_JSON")"
   if [ "$QUALIFIED" != "true" ]; then


### PR DESCRIPTION
## Summary

Renovate's native-SDK bucket holds a 3-day soak (`minimumReleaseAge` in renovate.json), and nothing on the dependency dashboard can tick past it: rebasing #48 re-resolved correctly and still kept the older targets because the newer releases hadn't aged. The rule's own PR note already sanctions a manual PR for urgent bumps. This makes that path one command, and fixes the two existing scripts so it actually releases: running `qualify-sdk.sh` on #52 passed compat, then died posting an approving review, because GitHub won't let you approve your own PR, and `release-sdk-bump.sh` insisted on that approval. Renovate PRs never hit this because a bot authors them.

## Changes

- `scripts/bump-native-sdks.sh` (new): in a throwaway worktree, resolve each SDK's `latest` dist-tag (never a prerelease), rewrite the two exact pins, refresh the lockfile, push a branch, and open the PR. Exits cleanly when both are already current. Ends by printing the `qualify-sdk.sh` command.
- `scripts/qualify-sdk.sh`: on PASS, post the evidence as a comment review when the PR author is you, an approving review otherwise.
- `scripts/release-sdk-bump.sh`: accept the `SDK qualification: PASS` marker from an APPROVED or COMMENTED review. The marker was always the real signal; the review state wasn't.
- `docs/maintenance.md`: point the "urgent bumps" note at the script, and say to leave Renovate's own SDK PR open (closing it just makes Renovate re-open it, as #48 → #53 showed; it closes itself once the manual bump merges).

No changelog entry: maintainer tooling, not shipped behavior.

Verified `bash -n` on all three, the JSON rewrite on a copy of package.json, and non-prerelease `latest` resolution. The self-author branch is exercised by re-running `qualify-sdk.sh 52` after this merges.