### PR TITLE
Prepare 0.6.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ dependency-update policy.
 
 ## [Unreleased]
 
+## [0.6.5] - 2026-09-04
+
+### Changed
+
+- Updated `@anthropic-ai/claude-agent-sdk` from `0.3.252` to `0.3.260` and `@openai/codex-sdk` from `0.151.0` to `0.153.2`. Re-qualified both native adapters with `neal compat`; no behavior change.
+
 ## [0.6.4] - 2026-09-04
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@navels/neal",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "A source-first multi-agent CLI for planning, executing, reviewing, and resuming scoped code changes.",
   "license": "MIT",
   "publishConfig": {


### PR DESCRIPTION
## Summary

Release prep for 0.6.5, a patch release covering the dependency bumps from #52.

## Changes

- Bump `package.json.version` to 0.6.5
- Add the 0.6.5 changelog section:

- Updated `@anthropic-ai/claude-agent-sdk` from `0.3.252` to `0.3.260` and `@openai/codex-sdk` from `0.151.0` to `0.153.2`. Re-qualified both native adapters with `neal compat`; no behavior change.

All release gates pass locally via scripts/release-sdk-bump.sh.