### PR TITLE
Drop registry-url from the publish setup-node step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,7 +42,6 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: 24.20.0
-          registry-url: https://registry.npmjs.org
 
       - name: Upgrade npm for trusted publishing
         # Staged publishing requires npm >= 11.15.0.


### PR DESCRIPTION
## Summary

Every npm and pnpm step in the Publish job logs `[WARN] Failed to replace env in config: ${NODE_AUTH_TOKEN}`. `actions/setup-node` with `registry-url` writes a runner `.npmrc` containing `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` for token-based publishing, but neal publishes through trusted publishing (`id-token: write` plus npm's staged OIDC publish), so that variable is never set and the line is dead. Removing `registry-url` removes the line and the warning. The default registry is already npmjs.org.

## Changes

- `.github/workflows/publish.yml`: remove `registry-url` from the setup-node step

CI doesn't run the Publish workflow, so a green Verify here only proves the YAML is valid. The real check is the next release's Publish dry-run, which is the first step of every release anyway.