### PR TITLE
Tell a shell-only read-only reviewer how it reads the repository

### DIFF
--- a/src/neal/context/inline-review-context.ts
+++ b/src/neal/context/inline-review-context.ts
@@ -229,7 +229,7 @@ export function renderInlinedRangeDiffSection(args: { rangeLabel: string; diff: 
   return [
     `## Inlined commit-range diff from Neal (${args.rangeLabel})`,
     '',
-    'You have read-only repository tools (read and search, no shell) but no commit-range diff tool, so Neal has inlined the commit-range diff below.',
+    'You have read-only repository access but no commit-range diff tool, so Neal has inlined the commit-range diff below. That access may be dedicated read and search tools, or a shell running in a read-only sandbox; if it is a shell, use it only to read files and search the tree, never to write.',
     'This inlined diff is the source of truth for exactly what this range changed, including deletions and renames that head-state file reads cannot reveal. Use your read tools to verify the surrounding code.',
     '',
     args.diff.trim() === '' ? '(empty diff)' : truncateInlineSectionBody(args.diff),

--- a/src/neal/prompts/review-doctrine.ts
+++ b/src/neal/prompts/review-doctrine.ts
@@ -28,7 +28,7 @@ export type CodeReviewFalsificationContext = {
   // Only meaningful with mode === 'read-only'. When true, Neal has inlined the
   // commit-range diff into the reviewer prompt (the reviewer has read tools but
   // no commit-range diff tool), so the doctrine references that inlined diff as
-  // the source of truth and must not name a `git_diff` tool or instruct shell.
+  // the source of truth and must not name a `git_diff` tool.
   // When false (the default, e.g. openai-compatible), the doctrine keeps the
   // existing `git_diff`-tool phrasing.
   rangeDiffInlined?: boolean;
@@ -100,6 +100,7 @@ export function getCodeReviewFalsificationLines(context: CodeReviewFalsification
   if (mode === 'read-only') {
     lines.push(
       'A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.',
+      'Your read tools may be dedicated read and search tools, or a shell running in a read-only sandbox. If your only repository tool is that shell, use it to read files and search the tree (for example cat, sed -n, grep, ls); it cannot write, and you must not try to.',
     );
   }
 

--- a/src/neal/prompts/specs.ts
+++ b/src/neal/prompts/specs.ts
@@ -577,7 +577,7 @@ export const PROMPT_SPECS: readonly PromptSpec[] = [
   },
   {
     id: 'scope_reviewer',
-    version: 5,
+    version: 6,
     changelog: [
       {
         version: 1,
@@ -598,6 +598,10 @@ export const PROMPT_SPECS: readonly PromptSpec[] = [
       {
         version: 5,
         renderSha: 'e8dcb976d0ea22e9026e09a87d7dde93c8513334f62ad89472ebefe91771754b',
+      },
+      {
+        version: 6,
+        renderSha: 'ed8d66b768a869817ff4c6b3d127b0f6f3958dff3cf57e036cc27c21800201a4',
       },
     ],
     role: 'reviewer',
@@ -771,7 +775,7 @@ export const PROMPT_SPECS: readonly PromptSpec[] = [
   },
   {
     id: 'completion_reviewer',
-    version: 5,
+    version: 6,
     changelog: [
       {
         version: 1,
@@ -792,6 +796,10 @@ export const PROMPT_SPECS: readonly PromptSpec[] = [
       {
         version: 5,
         renderSha: '7930cec95560ad880bba94a7ae48e68c621805787261e295c4c405d09235c87b',
+      },
+      {
+        version: 6,
+        renderSha: '079a57a685c33aaba5b9a6b919ed4cb961a79f89e770ed6ede85020b618addd6',
       },
     ],
     role: 'reviewer',

--- a/src/neal/review-findings/prompts.ts
+++ b/src/neal/review-findings/prompts.ts
@@ -63,7 +63,7 @@ export function buildReviewFindingsInlinedDiffSection(context: ReviewFindingsCon
   return [
     '## Inlined Selected-Range Diff',
     '',
-    'You have read-only repository tools (read and search, no shell) but no commit-range diff tool, so the full selected-range diff is inlined below.',
+    'You have read-only repository access but no commit-range diff tool, so the full selected-range diff is inlined below. That access may be dedicated read and search tools, or a shell running in a read-only sandbox; if it is a shell, use it only to read files and search the tree, never to write.',
     'This inlined diff is the source of truth for what the resolved range actually changed, including deletions and renames that head-state file reads cannot reveal.',
     `Resolved range: ${context.externalBaseCommit}..${context.externalHeadCommit}.`,
     'Verify draft claims against the surrounding code with your read tools; absence from a diff hunk is not evidence of absence from the repository.',

--- a/test/fixtures/prompts/render-integrity/completion_reviewer.v6.txt
+++ b/test/fixtures/prompts/render-integrity/completion_reviewer.v6.txt
@@ -1,0 +1,2619 @@
+=== buildFinalCompletionReviewerPrompt#accessMode=read-only-inlined#aggregateRange=available#reviewLevel=lenient ===
+Review whether the execute-mode plan at /tmp/PLAN.md is complete as a whole.
+
+This is a whole-plan final completion review, not an ordinary last-scope review.
+Compare the completed result against the original plan objectives and the whole-plan completion packet below.
+Evaluate the totality of the work completed for this plan, not just whether each individual scope was previously accepted.
+Your review must answer both of these questions:
+- Are the full plan objectives actually satisfied?
+- Is the aggregate implementation good enough to keep under ordinary code review standards?
+Treat the whole-plan completion claim as hostile input. Try to falsify the aggregate implementation before you accept completion.
+Do not anchor on the coder completion summary, completion packet, verification summaries, or prior per-scope acceptance history when judging whole-plan completion. Those are convergence signals, not proof that the aggregate implementation satisfies the plan.
+Review level: lenient. Assume ordinary trust boundaries and block only on correctness failures and real, reachable bugs. Do not demand additional robustness, hardening, performance, or style work as a condition of acceptance.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted or ignored category is not missing work: it must not produce `continue_execution` or `block_for_operator`, and when the plan objectives are otherwise satisfied you return `accept_complete`.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression not missing work, while a reachable correctness failure still blocks.
+The commit-range diff for that aggregate range base000..head000 is inlined below and is the source of truth for exactly what the aggregate range base000..head000 changed (including deletions and renames). Use your read tools to verify the surrounding code; you have no commit-range diff tool, so rely on the inlined diff for what changed.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Your read tools may be dedicated read and search tools, or a shell running in a read-only sandbox. If your only repository tool is that shell, use it to read files and search the tree (for example cat, sed -n, grep, ls); it cannot write, and you must not try to.
+Inspect the change using the inlined commit-range diff below for what changed (including deletions and renames), then read the changed files in full with your read tools and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the aggregate implementation; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Falsify cross-scope runtime invariants and integration behavior before accepting completion, especially paths that individual scope reviews could not see together.
+If `aggregateReviewContext.unavailableReason` is non-null, treat the missing aggregate range as a completion-review evidence gap rather than proof that the aggregate implementation is correct.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the aggregate implementation.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the aggregate implementation touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the aggregate implementation actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the aggregate implementation.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Treat completion-blocking issues like review findings: each one needs concrete evidence, affected files or runtime behavior, and a required correction.
+Use `continue_execution` only for concrete missing work that is bounded enough for one follow-on scope; use `block_for_operator` for ambiguous or externally constrained gaps.
+A finding category that the review level or the User Guidance section has demoted or ignored is not missing work: never return `continue_execution` or `block_for_operator` for it. When the plan objectives are otherwise satisfied, return `accept_complete`.
+Do not turn low-signal style preferences, trivial code-shape preferences, or optional refactors into missing work.
+If the plan is complete aside from low-signal trivia, return `accept_complete` rather than inventing a non-blocking completion concern.
+Review the whole-plan result for correctness and completeness against the plan objectives, regressions or missing behavior, cross-scope integration issues that may not have been visible in individual scope reviews, code quality, maintainability, and consistency of the final implementation, and adequacy of test coverage and verification for the total change.
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+Do not treat prior per-scope acceptance as sufficient evidence that the whole plan is complete or that the aggregate code quality is acceptable.
+Return only JSON that matches the required schema.
+Return the final answer only as the required structured output object, not as prose or markdown.
+Defer exact output framing to the active structured-output transport; do not add your own output-format constraints.
+Use `accept_complete` only when the full plan objectives are satisfied and the aggregate implementation is acceptable under ordinary code review standards.
+Use `continue_execution` only when the remaining work is concrete, bounded, and suitable for one explicit follow-on scope.
+Use `block_for_operator` when the remaining gap is ambiguous, externally constrained, or needs human direction.
+When you return `continue_execution`, you must provide a non-null `missingWork` object with `summary`, `requiredOutcome`, and `verification`.
+When you return any other action, `missingWork` must be null.
+
+Squash commit message rules:
+- `squashCommitMessage` is project-facing Git history for human readers.
+- Use `squashCommitMessage` only for `accept_complete`; when you return any non-accept action, set `squashCommitMessage` to null.
+- For `accept_complete`, provide a non-null object with one concise project-facing `subject` and 2 to 5 high-level `bullets`.
+- Do not mention plan paths, markdown plan filenames, temporary run paths, scope-numbered or per-scope wording, final cleanup, Neal mechanics, provider process, or reviewer process.
+- Summarize the code or product behavior change, not the plan document.
+- Valid example: subject "Persist final completion review failures"; bullets ["Mark invalid verdicts failed", "Record phase error events"].
+- Invalid example: subject "Finish scope 4 cleanup"; bullets ["Summarize per-scope plan work", "Describe reviewer process"].
+
+Coder whole-plan completion summary:
+{
+  "planGoalSatisfied": false,
+  "whatChangedOverall": "Canonical render matrix pinned across prompt specs.",
+  "verificationSummary": "pnpm typecheck",
+  "remainingKnownGaps": [
+    "One documentation pass remains."
+  ]
+}
+
+Whole-plan completion packet:
+{
+  "executionShape": "multi_scope",
+  "currentScopeLabel": "6",
+  "acceptedScopeRecordCount": 5,
+  "blockedScopeCount": 0,
+  "scopeAccountingSummary": "5 accepted top-level records",
+  "verificationOnlyCompletion": false,
+  "aggregateReviewContext": {
+    "baseCommit": "base000",
+    "headCommit": "head000",
+    "range": "base000..head000",
+    "commitSubjects": [
+      "head000 canonical render matrix"
+    ],
+    "diffStat": " src/example.ts | 2 +-",
+    "changedFiles": [
+      "src/example.ts"
+    ],
+    "unavailableReason": null
+  },
+  "finalCommit": "head000",
+  "completedScopeSummary": "1 accepted; 2 accepted",
+  "terminalChangedFilesSummary": "src/example.ts",
+  "planChangedFilesSummary": "src/example.ts",
+  "verificationTally": {
+    "totalRuns": 1,
+    "distinctCommands": 1,
+    "passed": 1,
+    "failed": 0,
+    "unknown": 0,
+    "recentFailures": []
+  },
+  "lastNonEmptyImplementationScope": {
+    "number": "5",
+    "finalCommit": "head000",
+    "commitSubject": "canonical render matrix",
+    "changedFiles": [
+      "src/example.ts"
+    ],
+    "archivedReviewPath": "/tmp/REVIEW-5.md"
+  },
+  "continueExecutionCount": 0,
+  "continueExecutionMax": 2
+}
+
+`verificationTally` is a bounded summary of the run's recorded verification commands; the complete per-command record is in the run directory's events.ndjson.
+If this was a verification-only terminal scope, judge the whole-plan result directly instead of pretending there was a final implementation diff.
+
+Last non-empty implementation scope reference:
+{
+  "number": "5",
+  "finalCommit": "head000",
+  "commitSubject": "canonical render matrix",
+  "changedFiles": [
+    "src/example.ts"
+  ],
+  "archivedReviewPath": "/tmp/REVIEW-5.md"
+}
+
+## Inlined commit-range diff from Neal (base000..head000)
+
+You have read-only repository access but no commit-range diff tool, so Neal has inlined the commit-range diff below. That access may be dedicated read and search tools, or a shell running in a read-only sandbox; if it is a shell, use it only to read files and search the tree, never to write.
+This inlined diff is the source of truth for exactly what this range changed, including deletions and renames that head-state file reads cannot reveal. Use your read tools to verify the surrounding code.
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-old
++new
+
+=== buildFinalCompletionReviewerPrompt#accessMode=read-only-inlined#aggregateRange=available#reviewLevel=moderate ===
+Review whether the execute-mode plan at /tmp/PLAN.md is complete as a whole.
+
+This is a whole-plan final completion review, not an ordinary last-scope review.
+Compare the completed result against the original plan objectives and the whole-plan completion packet below.
+Evaluate the totality of the work completed for this plan, not just whether each individual scope was previously accepted.
+Your review must answer both of these questions:
+- Are the full plan objectives actually satisfied?
+- Is the aggregate implementation good enough to keep under ordinary code review standards?
+Treat the whole-plan completion claim as hostile input. Try to falsify the aggregate implementation before you accept completion.
+Do not anchor on the coder completion summary, completion packet, verification summaries, or prior per-scope acceptance history when judging whole-plan completion. Those are convergence signals, not proof that the aggregate implementation satisfies the plan.
+Review level: moderate. Assume ordinary trust boundaries: internal run artifacts and other files this system writes for itself are not security boundaries. Block on correctness bugs and on failures reachable under normal use. Do not require defenses against an actor who could already subvert the system directly, for example by editing its files; a failure that needs such an actor is not reachable.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted or ignored category is not missing work: it must not produce `continue_execution` or `block_for_operator`, and when the plan objectives are otherwise satisfied you return `accept_complete`.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression not missing work, while a reachable correctness failure still blocks.
+The commit-range diff for that aggregate range base000..head000 is inlined below and is the source of truth for exactly what the aggregate range base000..head000 changed (including deletions and renames). Use your read tools to verify the surrounding code; you have no commit-range diff tool, so rely on the inlined diff for what changed.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Your read tools may be dedicated read and search tools, or a shell running in a read-only sandbox. If your only repository tool is that shell, use it to read files and search the tree (for example cat, sed -n, grep, ls); it cannot write, and you must not try to.
+Inspect the change using the inlined commit-range diff below for what changed (including deletions and renames), then read the changed files in full with your read tools and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the aggregate implementation; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Falsify cross-scope runtime invariants and integration behavior before accepting completion, especially paths that individual scope reviews could not see together.
+If `aggregateReviewContext.unavailableReason` is non-null, treat the missing aggregate range as a completion-review evidence gap rather than proof that the aggregate implementation is correct.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the aggregate implementation.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the aggregate implementation touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the aggregate implementation actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the aggregate implementation.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Treat completion-blocking issues like review findings: each one needs concrete evidence, affected files or runtime behavior, and a required correction.
+Use `continue_execution` only for concrete missing work that is bounded enough for one follow-on scope; use `block_for_operator` for ambiguous or externally constrained gaps.
+A finding category that the review level or the User Guidance section has demoted or ignored is not missing work: never return `continue_execution` or `block_for_operator` for it. When the plan objectives are otherwise satisfied, return `accept_complete`.
+Do not turn low-signal style preferences, trivial code-shape preferences, or optional refactors into missing work.
+If the plan is complete aside from low-signal trivia, return `accept_complete` rather than inventing a non-blocking completion concern.
+Review the whole-plan result for correctness and completeness against the plan objectives, regressions or missing behavior, cross-scope integration issues that may not have been visible in individual scope reviews, code quality, maintainability, and consistency of the final implementation, and adequacy of test coverage and verification for the total change.
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+Do not treat prior per-scope acceptance as sufficient evidence that the whole plan is complete or that the aggregate code quality is acceptable.
+Return only JSON that matches the required schema.
+Return the final answer only as the required structured output object, not as prose or markdown.
+Defer exact output framing to the active structured-output transport; do not add your own output-format constraints.
+Use `accept_complete` only when the full plan objectives are satisfied and the aggregate implementation is acceptable under ordinary code review standards.
+Use `continue_execution` only when the remaining work is concrete, bounded, and suitable for one explicit follow-on scope.
+Use `block_for_operator` when the remaining gap is ambiguous, externally constrained, or needs human direction.
+When you return `continue_execution`, you must provide a non-null `missingWork` object with `summary`, `requiredOutcome`, and `verification`.
+When you return any other action, `missingWork` must be null.
+
+Squash commit message rules:
+- `squashCommitMessage` is project-facing Git history for human readers.
+- Use `squashCommitMessage` only for `accept_complete`; when you return any non-accept action, set `squashCommitMessage` to null.
+- For `accept_complete`, provide a non-null object with one concise project-facing `subject` and 2 to 5 high-level `bullets`.
+- Do not mention plan paths, markdown plan filenames, temporary run paths, scope-numbered or per-scope wording, final cleanup, Neal mechanics, provider process, or reviewer process.
+- Summarize the code or product behavior change, not the plan document.
+- Valid example: subject "Persist final completion review failures"; bullets ["Mark invalid verdicts failed", "Record phase error events"].
+- Invalid example: subject "Finish scope 4 cleanup"; bullets ["Summarize per-scope plan work", "Describe reviewer process"].
+
+Coder whole-plan completion summary:
+{
+  "planGoalSatisfied": false,
+  "whatChangedOverall": "Canonical render matrix pinned across prompt specs.",
+  "verificationSummary": "pnpm typecheck",
+  "remainingKnownGaps": [
+    "One documentation pass remains."
+  ]
+}
+
+Whole-plan completion packet:
+{
+  "executionShape": "multi_scope",
+  "currentScopeLabel": "6",
+  "acceptedScopeRecordCount": 5,
+  "blockedScopeCount": 0,
+  "scopeAccountingSummary": "5 accepted top-level records",
+  "verificationOnlyCompletion": false,
+  "aggregateReviewContext": {
+    "baseCommit": "base000",
+    "headCommit": "head000",
+    "range": "base000..head000",
+    "commitSubjects": [
+      "head000 canonical render matrix"
+    ],
+    "diffStat": " src/example.ts | 2 +-",
+    "changedFiles": [
+      "src/example.ts"
+    ],
+    "unavailableReason": null
+  },
+  "finalCommit": "head000",
+  "completedScopeSummary": "1 accepted; 2 accepted",
+  "terminalChangedFilesSummary": "src/example.ts",
+  "planChangedFilesSummary": "src/example.ts",
+  "verificationTally": {
+    "totalRuns": 1,
+    "distinctCommands": 1,
+    "passed": 1,
+    "failed": 0,
+    "unknown": 0,
+    "recentFailures": []
+  },
+  "lastNonEmptyImplementationScope": {
+    "number": "5",
+    "finalCommit": "head000",
+    "commitSubject": "canonical render matrix",
+    "changedFiles": [
+      "src/example.ts"
+    ],
+    "archivedReviewPath": "/tmp/REVIEW-5.md"
+  },
+  "continueExecutionCount": 0,
+  "continueExecutionMax": 2
+}
+
+`verificationTally` is a bounded summary of the run's recorded verification commands; the complete per-command record is in the run directory's events.ndjson.
+If this was a verification-only terminal scope, judge the whole-plan result directly instead of pretending there was a final implementation diff.
+
+Last non-empty implementation scope reference:
+{
+  "number": "5",
+  "finalCommit": "head000",
+  "commitSubject": "canonical render matrix",
+  "changedFiles": [
+    "src/example.ts"
+  ],
+  "archivedReviewPath": "/tmp/REVIEW-5.md"
+}
+
+## Inlined commit-range diff from Neal (base000..head000)
+
+You have read-only repository access but no commit-range diff tool, so Neal has inlined the commit-range diff below. That access may be dedicated read and search tools, or a shell running in a read-only sandbox; if it is a shell, use it only to read files and search the tree, never to write.
+This inlined diff is the source of truth for exactly what this range changed, including deletions and renames that head-state file reads cannot reveal. Use your read tools to verify the surrounding code.
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-old
++new
+
+=== buildFinalCompletionReviewerPrompt#accessMode=read-only-inlined#aggregateRange=available#reviewLevel=strict ===
+Review whether the execute-mode plan at /tmp/PLAN.md is complete as a whole.
+
+This is a whole-plan final completion review, not an ordinary last-scope review.
+Compare the completed result against the original plan objectives and the whole-plan completion packet below.
+Evaluate the totality of the work completed for this plan, not just whether each individual scope was previously accepted.
+Your review must answer both of these questions:
+- Are the full plan objectives actually satisfied?
+- Is the aggregate implementation good enough to keep under ordinary code review standards?
+Treat the whole-plan completion claim as hostile input. Try to falsify the aggregate implementation before you accept completion.
+Do not anchor on the coder completion summary, completion packet, verification summaries, or prior per-scope acceptance history when judging whole-plan completion. Those are convergence signals, not proof that the aggregate implementation satisfies the plan.
+Review level: strict. Assume adversarial trust boundaries: treat every input, file, and process the change can be reached from, including local processes and internal run artifacts, as a potential attacker. A hardening gap or a missing defense against a local or adversarial actor is a reachable failure under these boundaries and blocks.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted or ignored category is not missing work: it must not produce `continue_execution` or `block_for_operator`, and when the plan objectives are otherwise satisfied you return `accept_complete`.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression not missing work, while a reachable correctness failure still blocks.
+The commit-range diff for that aggregate range base000..head000 is inlined below and is the source of truth for exactly what the aggregate range base000..head000 changed (including deletions and renames). Use your read tools to verify the surrounding code; you have no commit-range diff tool, so rely on the inlined diff for what changed.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Your read tools may be dedicated read and search tools, or a shell running in a read-only sandbox. If your only repository tool is that shell, use it to read files and search the tree (for example cat, sed -n, grep, ls); it cannot write, and you must not try to.
+Inspect the change using the inlined commit-range diff below for what changed (including deletions and renames), then read the changed files in full with your read tools and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the aggregate implementation; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Falsify cross-scope runtime invariants and integration behavior before accepting completion, especially paths that individual scope reviews could not see together.
+If `aggregateReviewContext.unavailableReason` is non-null, treat the missing aggregate range as a completion-review evidence gap rather than proof that the aggregate implementation is correct.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the aggregate implementation.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the aggregate implementation touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the aggregate implementation actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the aggregate implementation.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Treat completion-blocking issues like review findings: each one needs concrete evidence, affected files or runtime behavior, and a required correction.
+Use `continue_execution` only for concrete missing work that is bounded enough for one follow-on scope; use `block_for_operator` for ambiguous or externally constrained gaps.
+A finding category that the review level or the User Guidance section has demoted or ignored is not missing work: never return `continue_execution` or `block_for_operator` for it. When the plan objectives are otherwise satisfied, return `accept_complete`.
+Do not turn low-signal style preferences, trivial code-shape preferences, or optional refactors into missing work.
+If the plan is complete aside from low-signal trivia, return `accept_complete` rather than inventing a non-blocking completion concern.
+Review the whole-plan result for correctness and completeness against the plan objectives, regressions or missing behavior, cross-scope integration issues that may not have been visible in individual scope reviews, code quality, maintainability, and consistency of the final implementation, and adequacy of test coverage and verification for the total change.
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+Do not treat prior per-scope acceptance as sufficient evidence that the whole plan is complete or that the aggregate code quality is acceptable.
+Return only JSON that matches the required schema.
+Return the final answer only as the required structured output object, not as prose or markdown.
+Defer exact output framing to the active structured-output transport; do not add your own output-format constraints.
+Use `accept_complete` only when the full plan objectives are satisfied and the aggregate implementation is acceptable under ordinary code review standards.
+Use `continue_execution` only when the remaining work is concrete, bounded, and suitable for one explicit follow-on scope.
+Use `block_for_operator` when the remaining gap is ambiguous, externally constrained, or needs human direction.
+When you return `continue_execution`, you must provide a non-null `missingWork` object with `summary`, `requiredOutcome`, and `verification`.
+When you return any other action, `missingWork` must be null.
+
+Squash commit message rules:
+- `squashCommitMessage` is project-facing Git history for human readers.
+- Use `squashCommitMessage` only for `accept_complete`; when you return any non-accept action, set `squashCommitMessage` to null.
+- For `accept_complete`, provide a non-null object with one concise project-facing `subject` and 2 to 5 high-level `bullets`.
+- Do not mention plan paths, markdown plan filenames, temporary run paths, scope-numbered or per-scope wording, final cleanup, Neal mechanics, provider process, or reviewer process.
+- Summarize the code or product behavior change, not the plan document.
+- Valid example: subject "Persist final completion review failures"; bullets ["Mark invalid verdicts failed", "Record phase error events"].
+- Invalid example: subject "Finish scope 4 cleanup"; bullets ["Summarize per-scope plan work", "Describe reviewer process"].
+
+Coder whole-plan completion summary:
+{
+  "planGoalSatisfied": false,
+  "whatChangedOverall": "Canonical render matrix pinned across prompt specs.",
+  "verificationSummary": "pnpm typecheck",
+  "remainingKnownGaps": [
+    "One documentation pass remains."
+  ]
+}
+
+Whole-plan completion packet:
+{
+  "executionShape": "multi_scope",
+  "currentScopeLabel": "6",
+  "acceptedScopeRecordCount": 5,
+  "blockedScopeCount": 0,
+  "scopeAccountingSummary": "5 accepted top-level records",
+  "verificationOnlyCompletion": false,
+  "aggregateReviewContext": {
+    "baseCommit": "base000",
+    "headCommit": "head000",
+    "range": "base000..head000",
+    "commitSubjects": [
+      "head000 canonical render matrix"
+    ],
+    "diffStat": " src/example.ts | 2 +-",
+    "changedFiles": [
+      "src/example.ts"
+    ],
+    "unavailableReason": null
+  },
+  "finalCommit": "head000",
+  "completedScopeSummary": "1 accepted; 2 accepted",
+  "terminalChangedFilesSummary": "src/example.ts",
+  "planChangedFilesSummary": "src/example.ts",
+  "verificationTally": {
+    "totalRuns": 1,
+    "distinctCommands": 1,
+    "passed": 1,
+    "failed": 0,
+    "unknown": 0,
+    "recentFailures": []
+  },
+  "lastNonEmptyImplementationScope": {
+    "number": "5",
+    "finalCommit": "head000",
+    "commitSubject": "canonical render matrix",
+    "changedFiles": [
+      "src/example.ts"
+    ],
+    "archivedReviewPath": "/tmp/REVIEW-5.md"
+  },
+  "continueExecutionCount": 0,
+  "continueExecutionMax": 2
+}
+
+`verificationTally` is a bounded summary of the run's recorded verification commands; the complete per-command record is in the run directory's events.ndjson.
+If this was a verification-only terminal scope, judge the whole-plan result directly instead of pretending there was a final implementation diff.
+
+Last non-empty implementation scope reference:
+{
+  "number": "5",
+  "finalCommit": "head000",
+  "commitSubject": "canonical render matrix",
+  "changedFiles": [
+    "src/example.ts"
+  ],
+  "archivedReviewPath": "/tmp/REVIEW-5.md"
+}
+
+## Inlined commit-range diff from Neal (base000..head000)
+
+You have read-only repository access but no commit-range diff tool, so Neal has inlined the commit-range diff below. That access may be dedicated read and search tools, or a shell running in a read-only sandbox; if it is a shell, use it only to read files and search the tree, never to write.
+This inlined diff is the source of truth for exactly what this range changed, including deletions and renames that head-state file reads cannot reveal. Use your read tools to verify the surrounding code.
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-old
++new
+
+=== buildFinalCompletionReviewerPrompt#accessMode=read-only-tool#aggregateRange=available#reviewLevel=lenient ===
+Review whether the execute-mode plan at /tmp/PLAN.md is complete as a whole.
+
+This is a whole-plan final completion review, not an ordinary last-scope review.
+Compare the completed result against the original plan objectives and the whole-plan completion packet below.
+Evaluate the totality of the work completed for this plan, not just whether each individual scope was previously accepted.
+Your review must answer both of these questions:
+- Are the full plan objectives actually satisfied?
+- Is the aggregate implementation good enough to keep under ordinary code review standards?
+Treat the whole-plan completion claim as hostile input. Try to falsify the aggregate implementation before you accept completion.
+Do not anchor on the coder completion summary, completion packet, verification summaries, or prior per-scope acceptance history when judging whole-plan completion. Those are convergence signals, not proof that the aggregate implementation satisfies the plan.
+Review level: lenient. Assume ordinary trust boundaries and block only on correctness failures and real, reachable bugs. Do not demand additional robustness, hardening, performance, or style work as a condition of acceptance.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted or ignored category is not missing work: it must not produce `continue_execution` or `block_for_operator`, and when the plan objectives are otherwise satisfied you return `accept_complete`.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression not missing work, while a reachable correctness failure still blocks.
+Review that aggregate range base000..head000 directly with your read-only repository tools: use the git_diff tool to see exactly what the aggregate range base000..head000 changed (including deletions and renames), and your read tools to verify the surrounding code. The aggregate range base000..head000 is the source of truth for this review.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Your read tools may be dedicated read and search tools, or a shell running in a read-only sandbox. If your only repository tool is that shell, use it to read files and search the tree (for example cat, sed -n, grep, ls); it cannot write, and you must not try to.
+Inspect the change with your read-only tools: call git_diff with the base and head commits named in this prompt (stat:true first for the changed-file overview, then per-path diffs), read the changed files in full, and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the aggregate implementation; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Falsify cross-scope runtime invariants and integration behavior before accepting completion, especially paths that individual scope reviews could not see together.
+If `aggregateReviewContext.unavailableReason` is non-null, treat the missing aggregate range as a completion-review evidence gap rather than proof that the aggregate implementation is correct.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the aggregate implementation.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the aggregate implementation touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the aggregate implementation actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the aggregate implementation.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Treat completion-blocking issues like review findings: each one needs concrete evidence, affected files or runtime behavior, and a required correction.
+Use `continue_execution` only for concrete missing work that is bounded enough for one follow-on scope; use `block_for_operator` for ambiguous or externally constrained gaps.
+A finding category that the review level or the User Guidance section has demoted or ignored is not missing work: never return `continue_execution` or `block_for_operator` for it. When the plan objectives are otherwise satisfied, return `accept_complete`.
+Do not turn low-signal style preferences, trivial code-shape preferences, or optional refactors into missing work.
+If the plan is complete aside from low-signal trivia, return `accept_complete` rather than inventing a non-blocking completion concern.
+Review the whole-plan result for correctness and completeness against the plan objectives, regressions or missing behavior, cross-scope integration issues that may not have been visible in individual scope reviews, code quality, maintainability, and consistency of the final implementation, and adequacy of test coverage and verification for the total change.
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+Do not treat prior per-scope acceptance as sufficient evidence that the whole plan is complete or that the aggregate code quality is acceptable.
+Return only JSON that matches the required schema.
+Return the final answer only as the required structured output object, not as prose or markdown.
+Defer exact output framing to the active structured-output transport; do not add your own output-format constraints.
+Use `accept_complete` only when the full plan objectives are satisfied and the aggregate implementation is acceptable under ordinary code review standards.
+Use `continue_execution` only when the remaining work is concrete, bounded, and suitable for one explicit follow-on scope.
+Use `block_for_operator` when the remaining gap is ambiguous, externally constrained, or needs human direction.
+When you return `continue_execution`, you must provide a non-null `missingWork` object with `summary`, `requiredOutcome`, and `verification`.
+When you return any other action, `missingWork` must be null.
+
+Squash commit message rules:
+- `squashCommitMessage` is project-facing Git history for human readers.
+- Use `squashCommitMessage` only for `accept_complete`; when you return any non-accept action, set `squashCommitMessage` to null.
+- For `accept_complete`, provide a non-null object with one concise project-facing `subject` and 2 to 5 high-level `bullets`.
+- Do not mention plan paths, markdown plan filenames, temporary run paths, scope-numbered or per-scope wording, final cleanup, Neal mechanics, provider process, or reviewer process.
+- Summarize the code or product behavior change, not the plan document.
+- Valid example: subject "Persist final completion review failures"; bullets ["Mark invalid verdicts failed", "Record phase error events"].
+- Invalid example: subject "Finish scope 4 cleanup"; bullets ["Summarize per-scope plan work", "Describe reviewer process"].
+
+Coder whole-plan completion summary:
+{
+  "planGoalSatisfied": false,
+  "whatChangedOverall": "Canonical render matrix pinned across prompt specs.",
+  "verificationSummary": "pnpm typecheck",
+  "remainingKnownGaps": [
+    "One documentation pass remains."
+  ]
+}
+
+Whole-plan completion packet:
+{
+  "executionShape": "multi_scope",
+  "currentScopeLabel": "6",
+  "acceptedScopeRecordCount": 5,
+  "blockedScopeCount": 0,
+  "scopeAccountingSummary": "5 accepted top-level records",
+  "verificationOnlyCompletion": false,
+  "aggregateReviewContext": {
+    "baseCommit": "base000",
+    "headCommit": "head000",
+    "range": "base000..head000",
+    "commitSubjects": [
+      "head000 canonical render matrix"
+    ],
+    "diffStat": " src/example.ts | 2 +-",
+    "changedFiles": [
+      "src/example.ts"
+    ],
+    "unavailableReason": null
+  },
+  "finalCommit": "head000",
+  "completedScopeSummary": "1 accepted; 2 accepted",
+  "terminalChangedFilesSummary": "src/example.ts",
+  "planChangedFilesSummary": "src/example.ts",
+  "verificationTally": {
+    "totalRuns": 1,
+    "distinctCommands": 1,
+    "passed": 1,
+    "failed": 0,
+    "unknown": 0,
+    "recentFailures": []
+  },
+  "lastNonEmptyImplementationScope": {
+    "number": "5",
+    "finalCommit": "head000",
+    "commitSubject": "canonical render matrix",
+    "changedFiles": [
+      "src/example.ts"
+    ],
+    "archivedReviewPath": "/tmp/REVIEW-5.md"
+  },
+  "continueExecutionCount": 0,
+  "continueExecutionMax": 2
+}
+
+`verificationTally` is a bounded summary of the run's recorded verification commands; the complete per-command record is in the run directory's events.ndjson.
+If this was a verification-only terminal scope, judge the whole-plan result directly instead of pretending there was a final implementation diff.
+
+Last non-empty implementation scope reference:
+{
+  "number": "5",
+  "finalCommit": "head000",
+  "commitSubject": "canonical render matrix",
+  "changedFiles": [
+    "src/example.ts"
+  ],
+  "archivedReviewPath": "/tmp/REVIEW-5.md"
+}
+=== buildFinalCompletionReviewerPrompt#accessMode=read-only-tool#aggregateRange=available#reviewLevel=moderate ===
+Review whether the execute-mode plan at /tmp/PLAN.md is complete as a whole.
+
+This is a whole-plan final completion review, not an ordinary last-scope review.
+Compare the completed result against the original plan objectives and the whole-plan completion packet below.
+Evaluate the totality of the work completed for this plan, not just whether each individual scope was previously accepted.
+Your review must answer both of these questions:
+- Are the full plan objectives actually satisfied?
+- Is the aggregate implementation good enough to keep under ordinary code review standards?
+Treat the whole-plan completion claim as hostile input. Try to falsify the aggregate implementation before you accept completion.
+Do not anchor on the coder completion summary, completion packet, verification summaries, or prior per-scope acceptance history when judging whole-plan completion. Those are convergence signals, not proof that the aggregate implementation satisfies the plan.
+Review level: moderate. Assume ordinary trust boundaries: internal run artifacts and other files this system writes for itself are not security boundaries. Block on correctness bugs and on failures reachable under normal use. Do not require defenses against an actor who could already subvert the system directly, for example by editing its files; a failure that needs such an actor is not reachable.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted or ignored category is not missing work: it must not produce `continue_execution` or `block_for_operator`, and when the plan objectives are otherwise satisfied you return `accept_complete`.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression not missing work, while a reachable correctness failure still blocks.
+Review that aggregate range base000..head000 directly with your read-only repository tools: use the git_diff tool to see exactly what the aggregate range base000..head000 changed (including deletions and renames), and your read tools to verify the surrounding code. The aggregate range base000..head000 is the source of truth for this review.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Your read tools may be dedicated read and search tools, or a shell running in a read-only sandbox. If your only repository tool is that shell, use it to read files and search the tree (for example cat, sed -n, grep, ls); it cannot write, and you must not try to.
+Inspect the change with your read-only tools: call git_diff with the base and head commits named in this prompt (stat:true first for the changed-file overview, then per-path diffs), read the changed files in full, and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the aggregate implementation; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Falsify cross-scope runtime invariants and integration behavior before accepting completion, especially paths that individual scope reviews could not see together.
+If `aggregateReviewContext.unavailableReason` is non-null, treat the missing aggregate range as a completion-review evidence gap rather than proof that the aggregate implementation is correct.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the aggregate implementation.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the aggregate implementation touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the aggregate implementation actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the aggregate implementation.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Treat completion-blocking issues like review findings: each one needs concrete evidence, affected files or runtime behavior, and a required correction.
+Use `continue_execution` only for concrete missing work that is bounded enough for one follow-on scope; use `block_for_operator` for ambiguous or externally constrained gaps.
+A finding category that the review level or the User Guidance section has demoted or ignored is not missing work: never return `continue_execution` or `block_for_operator` for it. When the plan objectives are otherwise satisfied, return `accept_complete`.
+Do not turn low-signal style preferences, trivial code-shape preferences, or optional refactors into missing work.
+If the plan is complete aside from low-signal trivia, return `accept_complete` rather than inventing a non-blocking completion concern.
+Review the whole-plan result for correctness and completeness against the plan objectives, regressions or missing behavior, cross-scope integration issues that may not have been visible in individual scope reviews, code quality, maintainability, and consistency of the final implementation, and adequacy of test coverage and verification for the total change.
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+Do not treat prior per-scope acceptance as sufficient evidence that the whole plan is complete or that the aggregate code quality is acceptable.
+Return only JSON that matches the required schema.
+Return the final answer only as the required structured output object, not as prose or markdown.
+Defer exact output framing to the active structured-output transport; do not add your own output-format constraints.
+Use `accept_complete` only when the full plan objectives are satisfied and the aggregate implementation is acceptable under ordinary code review standards.
+Use `continue_execution` only when the remaining work is concrete, bounded, and suitable for one explicit follow-on scope.
+Use `block_for_operator` when the remaining gap is ambiguous, externally constrained, or needs human direction.
+When you return `continue_execution`, you must provide a non-null `missingWork` object with `summary`, `requiredOutcome`, and `verification`.
+When you return any other action, `missingWork` must be null.
+
+Squash commit message rules:
+- `squashCommitMessage` is project-facing Git history for human readers.
+- Use `squashCommitMessage` only for `accept_complete`; when you return any non-accept action, set `squashCommitMessage` to null.
+- For `accept_complete`, provide a non-null object with one concise project-facing `subject` and 2 to 5 high-level `bullets`.
+- Do not mention plan paths, markdown plan filenames, temporary run paths, scope-numbered or per-scope wording, final cleanup, Neal mechanics, provider process, or reviewer process.
+- Summarize the code or product behavior change, not the plan document.
+- Valid example: subject "Persist final completion review failures"; bullets ["Mark invalid verdicts failed", "Record phase error events"].
+- Invalid example: subject "Finish scope 4 cleanup"; bullets ["Summarize per-scope plan work", "Describe reviewer process"].
+
+Coder whole-plan completion summary:
+{
+  "planGoalSatisfied": false,
+  "whatChangedOverall": "Canonical render matrix pinned across prompt specs.",
+  "verificationSummary": "pnpm typecheck",
+  "remainingKnownGaps": [
+    "One documentation pass remains."
+  ]
+}
+
+Whole-plan completion packet:
+{
+  "executionShape": "multi_scope",
+  "currentScopeLabel": "6",
+  "acceptedScopeRecordCount": 5,
+  "blockedScopeCount": 0,
+  "scopeAccountingSummary": "5 accepted top-level records",
+  "verificationOnlyCompletion": false,
+  "aggregateReviewContext": {
+    "baseCommit": "base000",
+    "headCommit": "head000",
+    "range": "base000..head000",
+    "commitSubjects": [
+      "head000 canonical render matrix"
+    ],
+    "diffStat": " src/example.ts | 2 +-",
+    "changedFiles": [
+      "src/example.ts"
+    ],
+    "unavailableReason": null
+  },
+  "finalCommit": "head000",
+  "completedScopeSummary": "1 accepted; 2 accepted",
+  "terminalChangedFilesSummary": "src/example.ts",
+  "planChangedFilesSummary": "src/example.ts",
+  "verificationTally": {
+    "totalRuns": 1,
+    "distinctCommands": 1,
+    "passed": 1,
+    "failed": 0,
+    "unknown": 0,
+    "recentFailures": []
+  },
+  "lastNonEmptyImplementationScope": {
+    "number": "5",
+    "finalCommit": "head000",
+    "commitSubject": "canonical render matrix",
+    "changedFiles": [
+      "src/example.ts"
+    ],
+    "archivedReviewPath": "/tmp/REVIEW-5.md"
+  },
+  "continueExecutionCount": 0,
+  "continueExecutionMax": 2
+}
+
+`verificationTally` is a bounded summary of the run's recorded verification commands; the complete per-command record is in the run directory's events.ndjson.
+If this was a verification-only terminal scope, judge the whole-plan result directly instead of pretending there was a final implementation diff.
+
+Last non-empty implementation scope reference:
+{
+  "number": "5",
+  "finalCommit": "head000",
+  "commitSubject": "canonical render matrix",
+  "changedFiles": [
+    "src/example.ts"
+  ],
+  "archivedReviewPath": "/tmp/REVIEW-5.md"
+}
+=== buildFinalCompletionReviewerPrompt#accessMode=read-only-tool#aggregateRange=available#reviewLevel=strict ===
+Review whether the execute-mode plan at /tmp/PLAN.md is complete as a whole.
+
+This is a whole-plan final completion review, not an ordinary last-scope review.
+Compare the completed result against the original plan objectives and the whole-plan completion packet below.
+Evaluate the totality of the work completed for this plan, not just whether each individual scope was previously accepted.
+Your review must answer both of these questions:
+- Are the full plan objectives actually satisfied?
+- Is the aggregate implementation good enough to keep under ordinary code review standards?
+Treat the whole-plan completion claim as hostile input. Try to falsify the aggregate implementation before you accept completion.
+Do not anchor on the coder completion summary, completion packet, verification summaries, or prior per-scope acceptance history when judging whole-plan completion. Those are convergence signals, not proof that the aggregate implementation satisfies the plan.
+Review level: strict. Assume adversarial trust boundaries: treat every input, file, and process the change can be reached from, including local processes and internal run artifacts, as a potential attacker. A hardening gap or a missing defense against a local or adversarial actor is a reachable failure under these boundaries and blocks.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted or ignored category is not missing work: it must not produce `continue_execution` or `block_for_operator`, and when the plan objectives are otherwise satisfied you return `accept_complete`.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression not missing work, while a reachable correctness failure still blocks.
+Review that aggregate range base000..head000 directly with your read-only repository tools: use the git_diff tool to see exactly what the aggregate range base000..head000 changed (including deletions and renames), and your read tools to verify the surrounding code. The aggregate range base000..head000 is the source of truth for this review.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Your read tools may be dedicated read and search tools, or a shell running in a read-only sandbox. If your only repository tool is that shell, use it to read files and search the tree (for example cat, sed -n, grep, ls); it cannot write, and you must not try to.
+Inspect the change with your read-only tools: call git_diff with the base and head commits named in this prompt (stat:true first for the changed-file overview, then per-path diffs), read the changed files in full, and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the aggregate implementation; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Falsify cross-scope runtime invariants and integration behavior before accepting completion, especially paths that individual scope reviews could not see together.
+If `aggregateReviewContext.unavailableReason` is non-null, treat the missing aggregate range as a completion-review evidence gap rather than proof that the aggregate implementation is correct.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the aggregate implementation.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the aggregate implementation touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the aggregate implementation actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the aggregate implementation.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Treat completion-blocking issues like review findings: each one needs concrete evidence, affected files or runtime behavior, and a required correction.
+Use `continue_execution` only for concrete missing work that is bounded enough for one follow-on scope; use `block_for_operator` for ambiguous or externally constrained gaps.
+A finding category that the review level or the User Guidance section has demoted or ignored is not missing work: never return `continue_execution` or `block_for_operator` for it. When the plan objectives are otherwise satisfied, return `accept_complete`.
+Do not turn low-signal style preferences, trivial code-shape preferences, or optional refactors into missing work.
+If the plan is complete aside from low-signal trivia, return `accept_complete` rather than inventing a non-blocking completion concern.
+Review the whole-plan result for correctness and completeness against the plan objectives, regressions or missing behavior, cross-scope integration issues that may not have been visible in individual scope reviews, code quality, maintainability, and consistency of the final implementation, and adequacy of test coverage and verification for the total change.
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+Do not treat prior per-scope acceptance as sufficient evidence that the whole plan is complete or that the aggregate code quality is acceptable.
+Return only JSON that matches the required schema.
+Return the final answer only as the required structured output object, not as prose or markdown.
+Defer exact output framing to the active structured-output transport; do not add your own output-format constraints.
+Use `accept_complete` only when the full plan objectives are satisfied and the aggregate implementation is acceptable under ordinary code review standards.
+Use `continue_execution` only when the remaining work is concrete, bounded, and suitable for one explicit follow-on scope.
+Use `block_for_operator` when the remaining gap is ambiguous, externally constrained, or needs human direction.
+When you return `continue_execution`, you must provide a non-null `missingWork` object with `summary`, `requiredOutcome`, and `verification`.
+When you return any other action, `missingWork` must be null.
+
+Squash commit message rules:
+- `squashCommitMessage` is project-facing Git history for human readers.
+- Use `squashCommitMessage` only for `accept_complete`; when you return any non-accept action, set `squashCommitMessage` to null.
+- For `accept_complete`, provide a non-null object with one concise project-facing `subject` and 2 to 5 high-level `bullets`.
+- Do not mention plan paths, markdown plan filenames, temporary run paths, scope-numbered or per-scope wording, final cleanup, Neal mechanics, provider process, or reviewer process.
+- Summarize the code or product behavior change, not the plan document.
+- Valid example: subject "Persist final completion review failures"; bullets ["Mark invalid verdicts failed", "Record phase error events"].
+- Invalid example: subject "Finish scope 4 cleanup"; bullets ["Summarize per-scope plan work", "Describe reviewer process"].
+
+Coder whole-plan completion summary:
+{
+  "planGoalSatisfied": false,
+  "whatChangedOverall": "Canonical render matrix pinned across prompt specs.",
+  "verificationSummary": "pnpm typecheck",
+  "remainingKnownGaps": [
+    "One documentation pass remains."
+  ]
+}
+
+Whole-plan completion packet:
+{
+  "executionShape": "multi_scope",
+  "currentScopeLabel": "6",
+  "acceptedScopeRecordCount": 5,
+  "blockedScopeCount": 0,
+  "scopeAccountingSummary": "5 accepted top-level records",
+  "verificationOnlyCompletion": false,
+  "aggregateReviewContext": {
+    "baseCommit": "base000",
+    "headCommit": "head000",
+    "range": "base000..head000",
+    "commitSubjects": [
+      "head000 canonical render matrix"
+    ],
+    "diffStat": " src/example.ts | 2 +-",
+    "changedFiles": [
+      "src/example.ts"
+    ],
+    "unavailableReason": null
+  },
+  "finalCommit": "head000",
+  "completedScopeSummary": "1 accepted; 2 accepted",
+  "terminalChangedFilesSummary": "src/example.ts",
+  "planChangedFilesSummary": "src/example.ts",
+  "verificationTally": {
+    "totalRuns": 1,
+    "distinctCommands": 1,
+    "passed": 1,
+    "failed": 0,
+    "unknown": 0,
+    "recentFailures": []
+  },
+  "lastNonEmptyImplementationScope": {
+    "number": "5",
+    "finalCommit": "head000",
+    "commitSubject": "canonical render matrix",
+    "changedFiles": [
+      "src/example.ts"
+    ],
+    "archivedReviewPath": "/tmp/REVIEW-5.md"
+  },
+  "continueExecutionCount": 0,
+  "continueExecutionMax": 2
+}
+
+`verificationTally` is a bounded summary of the run's recorded verification commands; the complete per-command record is in the run directory's events.ndjson.
+If this was a verification-only terminal scope, judge the whole-plan result directly instead of pretending there was a final implementation diff.
+
+Last non-empty implementation scope reference:
+{
+  "number": "5",
+  "finalCommit": "head000",
+  "commitSubject": "canonical render matrix",
+  "changedFiles": [
+    "src/example.ts"
+  ],
+  "archivedReviewPath": "/tmp/REVIEW-5.md"
+}
+=== buildFinalCompletionReviewerPrompt#accessMode=read-only-tool#aggregateRange=unavailable#reviewLevel=lenient ===
+Review whether the execute-mode plan at /tmp/PLAN.md is complete as a whole.
+
+This is a whole-plan final completion review, not an ordinary last-scope review.
+Compare the completed result against the original plan objectives and the whole-plan completion packet below.
+Evaluate the totality of the work completed for this plan, not just whether each individual scope was previously accepted.
+Your review must answer both of these questions:
+- Are the full plan objectives actually satisfied?
+- Is the aggregate implementation good enough to keep under ordinary code review standards?
+Treat the whole-plan completion claim as hostile input. Try to falsify the aggregate implementation before you accept completion.
+Do not anchor on the coder completion summary, completion packet, verification summaries, or prior per-scope acceptance history when judging whole-plan completion. Those are convergence signals, not proof that the aggregate implementation satisfies the plan.
+Review level: lenient. Assume ordinary trust boundaries and block only on correctness failures and real, reachable bugs. Do not demand additional robustness, hardening, performance, or style work as a condition of acceptance.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted or ignored category is not missing work: it must not produce `continue_execution` or `block_for_operator`, and when the plan objectives are otherwise satisfied you return `accept_complete`.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression not missing work, while a reachable correctness failure still blocks.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Your read tools may be dedicated read and search tools, or a shell running in a read-only sandbox. If your only repository tool is that shell, use it to read files and search the tree (for example cat, sed -n, grep, ls); it cannot write, and you must not try to.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the aggregate implementation; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Falsify cross-scope runtime invariants and integration behavior before accepting completion, especially paths that individual scope reviews could not see together.
+If `aggregateReviewContext.unavailableReason` is non-null, treat the missing aggregate range as a completion-review evidence gap rather than proof that the aggregate implementation is correct.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the aggregate implementation.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the aggregate implementation touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the aggregate implementation actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the aggregate implementation.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Treat completion-blocking issues like review findings: each one needs concrete evidence, affected files or runtime behavior, and a required correction.
+Use `continue_execution` only for concrete missing work that is bounded enough for one follow-on scope; use `block_for_operator` for ambiguous or externally constrained gaps.
+A finding category that the review level or the User Guidance section has demoted or ignored is not missing work: never return `continue_execution` or `block_for_operator` for it. When the plan objectives are otherwise satisfied, return `accept_complete`.
+Do not turn low-signal style preferences, trivial code-shape preferences, or optional refactors into missing work.
+If the plan is complete aside from low-signal trivia, return `accept_complete` rather than inventing a non-blocking completion concern.
+Review the whole-plan result for correctness and completeness against the plan objectives, regressions or missing behavior, cross-scope integration issues that may not have been visible in individual scope reviews, code quality, maintainability, and consistency of the final implementation, and adequacy of test coverage and verification for the total change.
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+Do not treat prior per-scope acceptance as sufficient evidence that the whole plan is complete or that the aggregate code quality is acceptable.
+Return only JSON that matches the required schema.
+Return the final answer only as the required structured output object, not as prose or markdown.
+Defer exact output framing to the active structured-output transport; do not add your own output-format constraints.
+Use `accept_complete` only when the full plan objectives are satisfied and the aggregate implementation is acceptable under ordinary code review standards.
+Use `continue_execution` only when the remaining work is concrete, bounded, and suitable for one explicit follow-on scope.
+Use `block_for_operator` when the remaining gap is ambiguous, externally constrained, or needs human direction.
+When you return `continue_execution`, you must provide a non-null `missingWork` object with `summary`, `requiredOutcome`, and `verification`.
+When you return any other action, `missingWork` must be null.
+
+Squash commit message rules:
+- `squashCommitMessage` is project-facing Git history for human readers.
+- Use `squashCommitMessage` only for `accept_complete`; when you return any non-accept action, set `squashCommitMessage` to null.
+- For `accept_complete`, provide a non-null object with one concise project-facing `subject` and 2 to 5 high-level `bullets`.
+- Do not mention plan paths, markdown plan filenames, temporary run paths, scope-numbered or per-scope wording, final cleanup, Neal mechanics, provider process, or reviewer process.
+- Summarize the code or product behavior change, not the plan document.
+- Valid example: subject "Persist final completion review failures"; bullets ["Mark invalid verdicts failed", "Record phase error events"].
+- Invalid example: subject "Finish scope 4 cleanup"; bullets ["Summarize per-scope plan work", "Describe reviewer process"].
+
+Coder whole-plan completion summary:
+{
+  "planGoalSatisfied": false,
+  "whatChangedOverall": "Canonical render matrix pinned across prompt specs.",
+  "verificationSummary": "pnpm typecheck",
+  "remainingKnownGaps": [
+    "One documentation pass remains."
+  ]
+}
+
+Whole-plan completion packet:
+{
+  "executionShape": "multi_scope",
+  "currentScopeLabel": "6",
+  "acceptedScopeRecordCount": 5,
+  "blockedScopeCount": 0,
+  "scopeAccountingSummary": "5 accepted top-level records",
+  "verificationOnlyCompletion": false,
+  "aggregateReviewContext": {
+    "baseCommit": null,
+    "headCommit": null,
+    "range": null,
+    "commitSubjects": [],
+    "diffStat": "",
+    "changedFiles": [],
+    "unavailableReason": "no aggregate commit range was resolved"
+  },
+  "finalCommit": null,
+  "completedScopeSummary": "1 accepted; 2 accepted",
+  "terminalChangedFilesSummary": "src/example.ts",
+  "planChangedFilesSummary": "src/example.ts",
+  "verificationTally": {
+    "totalRuns": 1,
+    "distinctCommands": 1,
+    "passed": 1,
+    "failed": 0,
+    "unknown": 0,
+    "recentFailures": []
+  },
+  "lastNonEmptyImplementationScope": {
+    "number": "5",
+    "finalCommit": "head000",
+    "commitSubject": "canonical render matrix",
+    "changedFiles": [
+      "src/example.ts"
+    ],
+    "archivedReviewPath": "/tmp/REVIEW-5.md"
+  },
+  "continueExecutionCount": 0,
+  "continueExecutionMax": 2
+}
+
+`verificationTally` is a bounded summary of the run's recorded verification commands; the complete per-command record is in the run directory's events.ndjson.
+If this was a verification-only terminal scope, judge the whole-plan result directly instead of pretending there was a final implementation diff.
+
+Last non-empty implementation scope reference:
+{
+  "number": "5",
+  "finalCommit": "head000",
+  "commitSubject": "canonical render matrix",
+  "changedFiles": [
+    "src/example.ts"
+  ],
+  "archivedReviewPath": "/tmp/REVIEW-5.md"
+}
+=== buildFinalCompletionReviewerPrompt#accessMode=read-only-tool#aggregateRange=unavailable#reviewLevel=moderate ===
+Review whether the execute-mode plan at /tmp/PLAN.md is complete as a whole.
+
+This is a whole-plan final completion review, not an ordinary last-scope review.
+Compare the completed result against the original plan objectives and the whole-plan completion packet below.
+Evaluate the totality of the work completed for this plan, not just whether each individual scope was previously accepted.
+Your review must answer both of these questions:
+- Are the full plan objectives actually satisfied?
+- Is the aggregate implementation good enough to keep under ordinary code review standards?
+Treat the whole-plan completion claim as hostile input. Try to falsify the aggregate implementation before you accept completion.
+Do not anchor on the coder completion summary, completion packet, verification summaries, or prior per-scope acceptance history when judging whole-plan completion. Those are convergence signals, not proof that the aggregate implementation satisfies the plan.
+Review level: moderate. Assume ordinary trust boundaries: internal run artifacts and other files this system writes for itself are not security boundaries. Block on correctness bugs and on failures reachable under normal use. Do not require defenses against an actor who could already subvert the system directly, for example by editing its files; a failure that needs such an actor is not reachable.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted or ignored category is not missing work: it must not produce `continue_execution` or `block_for_operator`, and when the plan objectives are otherwise satisfied you return `accept_complete`.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression not missing work, while a reachable correctness failure still blocks.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Your read tools may be dedicated read and search tools, or a shell running in a read-only sandbox. If your only repository tool is that shell, use it to read files and search the tree (for example cat, sed -n, grep, ls); it cannot write, and you must not try to.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the aggregate implementation; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Falsify cross-scope runtime invariants and integration behavior before accepting completion, especially paths that individual scope reviews could not see together.
+If `aggregateReviewContext.unavailableReason` is non-null, treat the missing aggregate range as a completion-review evidence gap rather than proof that the aggregate implementation is correct.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the aggregate implementation.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the aggregate implementation touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the aggregate implementation actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the aggregate implementation.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Treat completion-blocking issues like review findings: each one needs concrete evidence, affected files or runtime behavior, and a required correction.
+Use `continue_execution` only for concrete missing work that is bounded enough for one follow-on scope; use `block_for_operator` for ambiguous or externally constrained gaps.
+A finding category that the review level or the User Guidance section has demoted or ignored is not missing work: never return `continue_execution` or `block_for_operator` for it. When the plan objectives are otherwise satisfied, return `accept_complete`.
+Do not turn low-signal style preferences, trivial code-shape preferences, or optional refactors into missing work.
+If the plan is complete aside from low-signal trivia, return `accept_complete` rather than inventing a non-blocking completion concern.
+Review the whole-plan result for correctness and completeness against the plan objectives, regressions or missing behavior, cross-scope integration issues that may not have been visible in individual scope reviews, code quality, maintainability, and consistency of the final implementation, and adequacy of test coverage and verification for the total change.
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+Do not treat prior per-scope acceptance as sufficient evidence that the whole plan is complete or that the aggregate code quality is acceptable.
+Return only JSON that matches the required schema.
+Return the final answer only as the required structured output object, not as prose or markdown.
+Defer exact output framing to the active structured-output transport; do not add your own output-format constraints.
+Use `accept_complete` only when the full plan objectives are satisfied and the aggregate implementation is acceptable under ordinary code review standards.
+Use `continue_execution` only when the remaining work is concrete, bounded, and suitable for one explicit follow-on scope.
+Use `block_for_operator` when the remaining gap is ambiguous, externally constrained, or needs human direction.
+When you return `continue_execution`, you must provide a non-null `missingWork` object with `summary`, `requiredOutcome`, and `verification`.
+When you return any other action, `missingWork` must be null.
+
+Squash commit message rules:
+- `squashCommitMessage` is project-facing Git history for human readers.
+- Use `squashCommitMessage` only for `accept_complete`; when you return any non-accept action, set `squashCommitMessage` to null.
+- For `accept_complete`, provide a non-null object with one concise project-facing `subject` and 2 to 5 high-level `bullets`.
+- Do not mention plan paths, markdown plan filenames, temporary run paths, scope-numbered or per-scope wording, final cleanup, Neal mechanics, provider process, or reviewer process.
+- Summarize the code or product behavior change, not the plan document.
+- Valid example: subject "Persist final completion review failures"; bullets ["Mark invalid verdicts failed", "Record phase error events"].
+- Invalid example: subject "Finish scope 4 cleanup"; bullets ["Summarize per-scope plan work", "Describe reviewer process"].
+
+Coder whole-plan completion summary:
+{
+  "planGoalSatisfied": false,
+  "whatChangedOverall": "Canonical render matrix pinned across prompt specs.",
+  "verificationSummary": "pnpm typecheck",
+  "remainingKnownGaps": [
+    "One documentation pass remains."
+  ]
+}
+
+Whole-plan completion packet:
+{
+  "executionShape": "multi_scope",
+  "currentScopeLabel": "6",
+  "acceptedScopeRecordCount": 5,
+  "blockedScopeCount": 0,
+  "scopeAccountingSummary": "5 accepted top-level records",
+  "verificationOnlyCompletion": false,
+  "aggregateReviewContext": {
+    "baseCommit": null,
+    "headCommit": null,
+    "range": null,
+    "commitSubjects": [],
+    "diffStat": "",
+    "changedFiles": [],
+    "unavailableReason": "no aggregate commit range was resolved"
+  },
+  "finalCommit": null,
+  "completedScopeSummary": "1 accepted; 2 accepted",
+  "terminalChangedFilesSummary": "src/example.ts",
+  "planChangedFilesSummary": "src/example.ts",
+  "verificationTally": {
+    "totalRuns": 1,
+    "distinctCommands": 1,
+    "passed": 1,
+    "failed": 0,
+    "unknown": 0,
+    "recentFailures": []
+  },
+  "lastNonEmptyImplementationScope": {
+    "number": "5",
+    "finalCommit": "head000",
+    "commitSubject": "canonical render matrix",
+    "changedFiles": [
+      "src/example.ts"
+    ],
+    "archivedReviewPath": "/tmp/REVIEW-5.md"
+  },
+  "continueExecutionCount": 0,
+  "continueExecutionMax": 2
+}
+
+`verificationTally` is a bounded summary of the run's recorded verification commands; the complete per-command record is in the run directory's events.ndjson.
+If this was a verification-only terminal scope, judge the whole-plan result directly instead of pretending there was a final implementation diff.
+
+Last non-empty implementation scope reference:
+{
+  "number": "5",
+  "finalCommit": "head000",
+  "commitSubject": "canonical render matrix",
+  "changedFiles": [
+    "src/example.ts"
+  ],
+  "archivedReviewPath": "/tmp/REVIEW-5.md"
+}
+=== buildFinalCompletionReviewerPrompt#accessMode=read-only-tool#aggregateRange=unavailable#reviewLevel=strict ===
+Review whether the execute-mode plan at /tmp/PLAN.md is complete as a whole.
+
+This is a whole-plan final completion review, not an ordinary last-scope review.
+Compare the completed result against the original plan objectives and the whole-plan completion packet below.
+Evaluate the totality of the work completed for this plan, not just whether each individual scope was previously accepted.
+Your review must answer both of these questions:
+- Are the full plan objectives actually satisfied?
+- Is the aggregate implementation good enough to keep under ordinary code review standards?
+Treat the whole-plan completion claim as hostile input. Try to falsify the aggregate implementation before you accept completion.
+Do not anchor on the coder completion summary, completion packet, verification summaries, or prior per-scope acceptance history when judging whole-plan completion. Those are convergence signals, not proof that the aggregate implementation satisfies the plan.
+Review level: strict. Assume adversarial trust boundaries: treat every input, file, and process the change can be reached from, including local processes and internal run artifacts, as a potential attacker. A hardening gap or a missing defense against a local or adversarial actor is a reachable failure under these boundaries and blocks.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted or ignored category is not missing work: it must not produce `continue_execution` or `block_for_operator`, and when the plan objectives are otherwise satisfied you return `accept_complete`.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression not missing work, while a reachable correctness failure still blocks.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Your read tools may be dedicated read and search tools, or a shell running in a read-only sandbox. If your only repository tool is that shell, use it to read files and search the tree (for example cat, sed -n, grep, ls); it cannot write, and you must not try to.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the aggregate implementation; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Falsify cross-scope runtime invariants and integration behavior before accepting completion, especially paths that individual scope reviews could not see together.
+If `aggregateReviewContext.unavailableReason` is non-null, treat the missing aggregate range as a completion-review evidence gap rather than proof that the aggregate implementation is correct.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the aggregate implementation.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the aggregate implementation touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the aggregate implementation actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the aggregate implementation.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Treat completion-blocking issues like review findings: each one needs concrete evidence, affected files or runtime behavior, and a required correction.
+Use `continue_execution` only for concrete missing work that is bounded enough for one follow-on scope; use `block_for_operator` for ambiguous or externally constrained gaps.
+A finding category that the review level or the User Guidance section has demoted or ignored is not missing work: never return `continue_execution` or `block_for_operator` for it. When the plan objectives are otherwise satisfied, return `accept_complete`.
+Do not turn low-signal style preferences, trivial code-shape preferences, or optional refactors into missing work.
+If the plan is complete aside from low-signal trivia, return `accept_complete` rather than inventing a non-blocking completion concern.
+Review the whole-plan result for correctness and completeness against the plan objectives, regressions or missing behavior, cross-scope integration issues that may not have been visible in individual scope reviews, code quality, maintainability, and consistency of the final implementation, and adequacy of test coverage and verification for the total change.
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+Do not treat prior per-scope acceptance as sufficient evidence that the whole plan is complete or that the aggregate code quality is acceptable.
+Return only JSON that matches the required schema.
+Return the final answer only as the required structured output object, not as prose or markdown.
+Defer exact output framing to the active structured-output transport; do not add your own output-format constraints.
+Use `accept_complete` only when the full plan objectives are satisfied and the aggregate implementation is acceptable under ordinary code review standards.
+Use `continue_execution` only when the remaining work is concrete, bounded, and suitable for one explicit follow-on scope.
+Use `block_for_operator` when the remaining gap is ambiguous, externally constrained, or needs human direction.
+When you return `continue_execution`, you must provide a non-null `missingWork` object with `summary`, `requiredOutcome`, and `verification`.
+When you return any other action, `missingWork` must be null.
+
+Squash commit message rules:
+- `squashCommitMessage` is project-facing Git history for human readers.
+- Use `squashCommitMessage` only for `accept_complete`; when you return any non-accept action, set `squashCommitMessage` to null.
+- For `accept_complete`, provide a non-null object with one concise project-facing `subject` and 2 to 5 high-level `bullets`.
+- Do not mention plan paths, markdown plan filenames, temporary run paths, scope-numbered or per-scope wording, final cleanup, Neal mechanics, provider process, or reviewer process.
+- Summarize the code or product behavior change, not the plan document.
+- Valid example: subject "Persist final completion review failures"; bullets ["Mark invalid verdicts failed", "Record phase error events"].
+- Invalid example: subject "Finish scope 4 cleanup"; bullets ["Summarize per-scope plan work", "Describe reviewer process"].
+
+Coder whole-plan completion summary:
+{
+  "planGoalSatisfied": false,
+  "whatChangedOverall": "Canonical render matrix pinned across prompt specs.",
+  "verificationSummary": "pnpm typecheck",
+  "remainingKnownGaps": [
+    "One documentation pass remains."
+  ]
+}
+
+Whole-plan completion packet:
+{
+  "executionShape": "multi_scope",
+  "currentScopeLabel": "6",
+  "acceptedScopeRecordCount": 5,
+  "blockedScopeCount": 0,
+  "scopeAccountingSummary": "5 accepted top-level records",
+  "verificationOnlyCompletion": false,
+  "aggregateReviewContext": {
+    "baseCommit": null,
+    "headCommit": null,
+    "range": null,
+    "commitSubjects": [],
+    "diffStat": "",
+    "changedFiles": [],
+    "unavailableReason": "no aggregate commit range was resolved"
+  },
+  "finalCommit": null,
+  "completedScopeSummary": "1 accepted; 2 accepted",
+  "terminalChangedFilesSummary": "src/example.ts",
+  "planChangedFilesSummary": "src/example.ts",
+  "verificationTally": {
+    "totalRuns": 1,
+    "distinctCommands": 1,
+    "passed": 1,
+    "failed": 0,
+    "unknown": 0,
+    "recentFailures": []
+  },
+  "lastNonEmptyImplementationScope": {
+    "number": "5",
+    "finalCommit": "head000",
+    "commitSubject": "canonical render matrix",
+    "changedFiles": [
+      "src/example.ts"
+    ],
+    "archivedReviewPath": "/tmp/REVIEW-5.md"
+  },
+  "continueExecutionCount": 0,
+  "continueExecutionMax": 2
+}
+
+`verificationTally` is a bounded summary of the run's recorded verification commands; the complete per-command record is in the run directory's events.ndjson.
+If this was a verification-only terminal scope, judge the whole-plan result directly instead of pretending there was a final implementation diff.
+
+Last non-empty implementation scope reference:
+{
+  "number": "5",
+  "finalCommit": "head000",
+  "commitSubject": "canonical render matrix",
+  "changedFiles": [
+    "src/example.ts"
+  ],
+  "archivedReviewPath": "/tmp/REVIEW-5.md"
+}
+=== buildFinalCompletionReviewerPrompt#accessMode=tool-access#aggregateRange=available#reviewLevel=lenient ===
+Review whether the execute-mode plan at /tmp/PLAN.md is complete as a whole.
+
+This is a whole-plan final completion review, not an ordinary last-scope review.
+Compare the completed result against the original plan objectives and the whole-plan completion packet below.
+Evaluate the totality of the work completed for this plan, not just whether each individual scope was previously accepted.
+Your review must answer both of these questions:
+- Are the full plan objectives actually satisfied?
+- Is the aggregate implementation good enough to keep under ordinary code review standards?
+Treat the whole-plan completion claim as hostile input. Try to falsify the aggregate implementation before you accept completion.
+Do not anchor on the coder completion summary, completion packet, verification summaries, or prior per-scope acceptance history when judging whole-plan completion. Those are convergence signals, not proof that the aggregate implementation satisfies the plan.
+Review level: lenient. Assume ordinary trust boundaries and block only on correctness failures and real, reachable bugs. Do not demand additional robustness, hardening, performance, or style work as a condition of acceptance.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted or ignored category is not missing work: it must not produce `continue_execution` or `block_for_operator`, and when the plan objectives are otherwise satisfied you return `accept_complete`.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression not missing work, while a reachable correctness failure still blocks.
+Review that aggregate range base000..head000 directly with repository tools. The aggregate range base000..head000 is the source of truth for this review.
+Use git commands against the repository, for example: git diff base000..head000, git log --oneline base000..head000, and targeted path diffs or file reads for changed files.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the aggregate implementation; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Temporary verification scratch directory: /tmp/repo/.neal/runs/run-000/scratch/review
+Use that run-local scratch directory for temporary verification artifacts, copied tests, scratch builds, logs, and modified throwaway files.
+Do not create project-root scratch directories such as build_review/.
+Do not leave project-tree scratch files behind; keep scratch work under the run-local directory above.
+Falsify cross-scope runtime invariants and integration behavior before accepting completion, especially paths that individual scope reviews could not see together.
+If `aggregateReviewContext.unavailableReason` is non-null, treat the missing aggregate range as a completion-review evidence gap rather than proof that the aggregate implementation is correct.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the aggregate implementation.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the aggregate implementation touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — running them when available — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the aggregate implementation actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the aggregate implementation.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, exercise or reason through the affected existing flows directly — run the most relevant existing tests or reproduce the reported behavior when practical — rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Treat completion-blocking issues like review findings: each one needs concrete evidence, affected files or runtime behavior, and a required correction.
+Use `continue_execution` only for concrete missing work that is bounded enough for one follow-on scope; use `block_for_operator` for ambiguous or externally constrained gaps.
+A finding category that the review level or the User Guidance section has demoted or ignored is not missing work: never return `continue_execution` or `block_for_operator` for it. When the plan objectives are otherwise satisfied, return `accept_complete`.
+Do not turn low-signal style preferences, trivial code-shape preferences, or optional refactors into missing work.
+If the plan is complete aside from low-signal trivia, return `accept_complete` rather than inventing a non-blocking completion concern.
+Review the whole-plan result for correctness and completeness against the plan objectives, regressions or missing behavior, cross-scope integration issues that may not have been visible in individual scope reviews, code quality, maintainability, and consistency of the final implementation, and adequacy of test coverage and verification for the total change.
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+Do not treat prior per-scope acceptance as sufficient evidence that the whole plan is complete or that the aggregate code quality is acceptable.
+Return only JSON that matches the required schema.
+Return the final answer only as the required structured output object, not as prose or markdown.
+Defer exact output framing to the active structured-output transport; do not add your own output-format constraints.
+Use `accept_complete` only when the full plan objectives are satisfied and the aggregate implementation is acceptable under ordinary code review standards.
+Use `continue_execution` only when the remaining work is concrete, bounded, and suitable for one explicit follow-on scope.
+Use `block_for_operator` when the remaining gap is ambiguous, externally constrained, or needs human direction.
+When you return `continue_execution`, you must provide a non-null `missingWork` object with `summary`, `requiredOutcome`, and `verification`.
+When you return any other action, `missingWork` must be null.
+
+Squash commit message rules:
+- `squashCommitMessage` is project-facing Git history for human readers.
+- Use `squashCommitMessage` only for `accept_complete`; when you return any non-accept action, set `squashCommitMessage` to null.
+- For `accept_complete`, provide a non-null object with one concise project-facing `subject` and 2 to 5 high-level `bullets`.
+- Do not mention plan paths, markdown plan filenames, temporary run paths, scope-numbered or per-scope wording, final cleanup, Neal mechanics, provider process, or reviewer process.
+- Summarize the code or product behavior change, not the plan document.
+- Valid example: subject "Persist final completion review failures"; bullets ["Mark invalid verdicts failed", "Record phase error events"].
+- Invalid example: subject "Finish scope 4 cleanup"; bullets ["Summarize per-scope plan work", "Describe reviewer process"].
+
+Coder whole-plan completion summary:
+{
+  "planGoalSatisfied": false,
+  "whatChangedOverall": "Canonical render matrix pinned across prompt specs.",
+  "verificationSummary": "pnpm typecheck",
+  "remainingKnownGaps": [
+    "One documentation pass remains."
+  ]
+}
+
+Whole-plan completion packet:
+{
+  "executionShape": "multi_scope",
+  "currentScopeLabel": "6",
+  "acceptedScopeRecordCount": 5,
+  "blockedScopeCount": 0,
+  "scopeAccountingSummary": "5 accepted top-level records",
+  "verificationOnlyCompletion": false,
+  "aggregateReviewContext": {
+    "baseCommit": "base000",
+    "headCommit": "head000",
+    "range": "base000..head000",
+    "commitSubjects": [
+      "head000 canonical render matrix"
+    ],
+    "diffStat": " src/example.ts | 2 +-",
+    "changedFiles": [
+      "src/example.ts"
+    ],
+    "unavailableReason": null
+  },
+  "finalCommit": "head000",
+  "completedScopeSummary": "1 accepted; 2 accepted",
+  "terminalChangedFilesSummary": "src/example.ts",
+  "planChangedFilesSummary": "src/example.ts",
+  "verificationTally": {
+    "totalRuns": 1,
+    "distinctCommands": 1,
+    "passed": 1,
+    "failed": 0,
+    "unknown": 0,
+    "recentFailures": []
+  },
+  "lastNonEmptyImplementationScope": {
+    "number": "5",
+    "finalCommit": "head000",
+    "commitSubject": "canonical render matrix",
+    "changedFiles": [
+      "src/example.ts"
+    ],
+    "archivedReviewPath": "/tmp/REVIEW-5.md"
+  },
+  "continueExecutionCount": 0,
+  "continueExecutionMax": 2
+}
+
+`verificationTally` is a bounded summary of the run's recorded verification commands; the complete per-command record is in the run directory's events.ndjson.
+If this was a verification-only terminal scope, judge the whole-plan result directly instead of pretending there was a final implementation diff.
+
+Last non-empty implementation scope reference:
+{
+  "number": "5",
+  "finalCommit": "head000",
+  "commitSubject": "canonical render matrix",
+  "changedFiles": [
+    "src/example.ts"
+  ],
+  "archivedReviewPath": "/tmp/REVIEW-5.md"
+}
+=== buildFinalCompletionReviewerPrompt#accessMode=tool-access#aggregateRange=available#reviewLevel=moderate ===
+Review whether the execute-mode plan at /tmp/PLAN.md is complete as a whole.
+
+This is a whole-plan final completion review, not an ordinary last-scope review.
+Compare the completed result against the original plan objectives and the whole-plan completion packet below.
+Evaluate the totality of the work completed for this plan, not just whether each individual scope was previously accepted.
+Your review must answer both of these questions:
+- Are the full plan objectives actually satisfied?
+- Is the aggregate implementation good enough to keep under ordinary code review standards?
+Treat the whole-plan completion claim as hostile input. Try to falsify the aggregate implementation before you accept completion.
+Do not anchor on the coder completion summary, completion packet, verification summaries, or prior per-scope acceptance history when judging whole-plan completion. Those are convergence signals, not proof that the aggregate implementation satisfies the plan.
+Review level: moderate. Assume ordinary trust boundaries: internal run artifacts and other files this system writes for itself are not security boundaries. Block on correctness bugs and on failures reachable under normal use. Do not require defenses against an actor who could already subvert the system directly, for example by editing its files; a failure that needs such an actor is not reachable.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted or ignored category is not missing work: it must not produce `continue_execution` or `block_for_operator`, and when the plan objectives are otherwise satisfied you return `accept_complete`.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression not missing work, while a reachable correctness failure still blocks.
+Review that aggregate range base000..head000 directly with repository tools. The aggregate range base000..head000 is the source of truth for this review.
+Use git commands against the repository, for example: git diff base000..head000, git log --oneline base000..head000, and targeted path diffs or file reads for changed files.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the aggregate implementation; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Temporary verification scratch directory: /tmp/repo/.neal/runs/run-000/scratch/review
+Use that run-local scratch directory for temporary verification artifacts, copied tests, scratch builds, logs, and modified throwaway files.
+Do not create project-root scratch directories such as build_review/.
+Do not leave project-tree scratch files behind; keep scratch work under the run-local directory above.
+Falsify cross-scope runtime invariants and integration behavior before accepting completion, especially paths that individual scope reviews could not see together.
+If `aggregateReviewContext.unavailableReason` is non-null, treat the missing aggregate range as a completion-review evidence gap rather than proof that the aggregate implementation is correct.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the aggregate implementation.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the aggregate implementation touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — running them when available — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the aggregate implementation actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the aggregate implementation.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, exercise or reason through the affected existing flows directly — run the most relevant existing tests or reproduce the reported behavior when practical — rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Treat completion-blocking issues like review findings: each one needs concrete evidence, affected files or runtime behavior, and a required correction.
+Use `continue_execution` only for concrete missing work that is bounded enough for one follow-on scope; use `block_for_operator` for ambiguous or externally constrained gaps.
+A finding category that the review level or the User Guidance section has demoted or ignored is not missing work: never return `continue_execution` or `block_for_operator` for it. When the plan objectives are otherwise satisfied, return `accept_complete`.
+Do not turn low-signal style preferences, trivial code-shape preferences, or optional refactors into missing work.
+If the plan is complete aside from low-signal trivia, return `accept_complete` rather than inventing a non-blocking completion concern.
+Review the whole-plan result for correctness and completeness against the plan objectives, regressions or missing behavior, cross-scope integration issues that may not have been visible in individual scope reviews, code quality, maintainability, and consistency of the final implementation, and adequacy of test coverage and verification for the total change.
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+Do not treat prior per-scope acceptance as sufficient evidence that the whole plan is complete or that the aggregate code quality is acceptable.
+Return only JSON that matches the required schema.
+Return the final answer only as the required structured output object, not as prose or markdown.
+Defer exact output framing to the active structured-output transport; do not add your own output-format constraints.
+Use `accept_complete` only when the full plan objectives are satisfied and the aggregate implementation is acceptable under ordinary code review standards.
+Use `continue_execution` only when the remaining work is concrete, bounded, and suitable for one explicit follow-on scope.
+Use `block_for_operator` when the remaining gap is ambiguous, externally constrained, or needs human direction.
+When you return `continue_execution`, you must provide a non-null `missingWork` object with `summary`, `requiredOutcome`, and `verification`.
+When you return any other action, `missingWork` must be null.
+
+Squash commit message rules:
+- `squashCommitMessage` is project-facing Git history for human readers.
+- Use `squashCommitMessage` only for `accept_complete`; when you return any non-accept action, set `squashCommitMessage` to null.
+- For `accept_complete`, provide a non-null object with one concise project-facing `subject` and 2 to 5 high-level `bullets`.
+- Do not mention plan paths, markdown plan filenames, temporary run paths, scope-numbered or per-scope wording, final cleanup, Neal mechanics, provider process, or reviewer process.
+- Summarize the code or product behavior change, not the plan document.
+- Valid example: subject "Persist final completion review failures"; bullets ["Mark invalid verdicts failed", "Record phase error events"].
+- Invalid example: subject "Finish scope 4 cleanup"; bullets ["Summarize per-scope plan work", "Describe reviewer process"].
+
+Coder whole-plan completion summary:
+{
+  "planGoalSatisfied": false,
+  "whatChangedOverall": "Canonical render matrix pinned across prompt specs.",
+  "verificationSummary": "pnpm typecheck",
+  "remainingKnownGaps": [
+    "One documentation pass remains."
+  ]
+}
+
+Whole-plan completion packet:
+{
+  "executionShape": "multi_scope",
+  "currentScopeLabel": "6",
+  "acceptedScopeRecordCount": 5,
+  "blockedScopeCount": 0,
+  "scopeAccountingSummary": "5 accepted top-level records",
+  "verificationOnlyCompletion": false,
+  "aggregateReviewContext": {
+    "baseCommit": "base000",
+    "headCommit": "head000",
+    "range": "base000..head000",
+    "commitSubjects": [
+      "head000 canonical render matrix"
+    ],
+    "diffStat": " src/example.ts | 2 +-",
+    "changedFiles": [
+      "src/example.ts"
+    ],
+    "unavailableReason": null
+  },
+  "finalCommit": "head000",
+  "completedScopeSummary": "1 accepted; 2 accepted",
+  "terminalChangedFilesSummary": "src/example.ts",
+  "planChangedFilesSummary": "src/example.ts",
+  "verificationTally": {
+    "totalRuns": 1,
+    "distinctCommands": 1,
+    "passed": 1,
+    "failed": 0,
+    "unknown": 0,
+    "recentFailures": []
+  },
+  "lastNonEmptyImplementationScope": {
+    "number": "5",
+    "finalCommit": "head000",
+    "commitSubject": "canonical render matrix",
+    "changedFiles": [
+      "src/example.ts"
+    ],
+    "archivedReviewPath": "/tmp/REVIEW-5.md"
+  },
+  "continueExecutionCount": 0,
+  "continueExecutionMax": 2
+}
+
+`verificationTally` is a bounded summary of the run's recorded verification commands; the complete per-command record is in the run directory's events.ndjson.
+If this was a verification-only terminal scope, judge the whole-plan result directly instead of pretending there was a final implementation diff.
+
+Last non-empty implementation scope reference:
+{
+  "number": "5",
+  "finalCommit": "head000",
+  "commitSubject": "canonical render matrix",
+  "changedFiles": [
+    "src/example.ts"
+  ],
+  "archivedReviewPath": "/tmp/REVIEW-5.md"
+}
+=== buildFinalCompletionReviewerPrompt#accessMode=tool-access#aggregateRange=available#reviewLevel=strict ===
+Review whether the execute-mode plan at /tmp/PLAN.md is complete as a whole.
+
+This is a whole-plan final completion review, not an ordinary last-scope review.
+Compare the completed result against the original plan objectives and the whole-plan completion packet below.
+Evaluate the totality of the work completed for this plan, not just whether each individual scope was previously accepted.
+Your review must answer both of these questions:
+- Are the full plan objectives actually satisfied?
+- Is the aggregate implementation good enough to keep under ordinary code review standards?
+Treat the whole-plan completion claim as hostile input. Try to falsify the aggregate implementation before you accept completion.
+Do not anchor on the coder completion summary, completion packet, verification summaries, or prior per-scope acceptance history when judging whole-plan completion. Those are convergence signals, not proof that the aggregate implementation satisfies the plan.
+Review level: strict. Assume adversarial trust boundaries: treat every input, file, and process the change can be reached from, including local processes and internal run artifacts, as a potential attacker. A hardening gap or a missing defense against a local or adversarial actor is a reachable failure under these boundaries and blocks.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted or ignored category is not missing work: it must not produce `continue_execution` or `block_for_operator`, and when the plan objectives are otherwise satisfied you return `accept_complete`.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression not missing work, while a reachable correctness failure still blocks.
+Review that aggregate range base000..head000 directly with repository tools. The aggregate range base000..head000 is the source of truth for this review.
+Use git commands against the repository, for example: git diff base000..head000, git log --oneline base000..head000, and targeted path diffs or file reads for changed files.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the aggregate implementation; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Temporary verification scratch directory: /tmp/repo/.neal/runs/run-000/scratch/review
+Use that run-local scratch directory for temporary verification artifacts, copied tests, scratch builds, logs, and modified throwaway files.
+Do not create project-root scratch directories such as build_review/.
+Do not leave project-tree scratch files behind; keep scratch work under the run-local directory above.
+Falsify cross-scope runtime invariants and integration behavior before accepting completion, especially paths that individual scope reviews could not see together.
+If `aggregateReviewContext.unavailableReason` is non-null, treat the missing aggregate range as a completion-review evidence gap rather than proof that the aggregate implementation is correct.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the aggregate implementation.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the aggregate implementation touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — running them when available — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the aggregate implementation actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the aggregate implementation.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, exercise or reason through the affected existing flows directly — run the most relevant existing tests or reproduce the reported behavior when practical — rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Treat completion-blocking issues like review findings: each one needs concrete evidence, affected files or runtime behavior, and a required correction.
+Use `continue_execution` only for concrete missing work that is bounded enough for one follow-on scope; use `block_for_operator` for ambiguous or externally constrained gaps.
+A finding category that the review level or the User Guidance section has demoted or ignored is not missing work: never return `continue_execution` or `block_for_operator` for it. When the plan objectives are otherwise satisfied, return `accept_complete`.
+Do not turn low-signal style preferences, trivial code-shape preferences, or optional refactors into missing work.
+If the plan is complete aside from low-signal trivia, return `accept_complete` rather than inventing a non-blocking completion concern.
+Review the whole-plan result for correctness and completeness against the plan objectives, regressions or missing behavior, cross-scope integration issues that may not have been visible in individual scope reviews, code quality, maintainability, and consistency of the final implementation, and adequacy of test coverage and verification for the total change.
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+Do not treat prior per-scope acceptance as sufficient evidence that the whole plan is complete or that the aggregate code quality is acceptable.
+Return only JSON that matches the required schema.
+Return the final answer only as the required structured output object, not as prose or markdown.
+Defer exact output framing to the active structured-output transport; do not add your own output-format constraints.
+Use `accept_complete` only when the full plan objectives are satisfied and the aggregate implementation is acceptable under ordinary code review standards.
+Use `continue_execution` only when the remaining work is concrete, bounded, and suitable for one explicit follow-on scope.
+Use `block_for_operator` when the remaining gap is ambiguous, externally constrained, or needs human direction.
+When you return `continue_execution`, you must provide a non-null `missingWork` object with `summary`, `requiredOutcome`, and `verification`.
+When you return any other action, `missingWork` must be null.
+
+Squash commit message rules:
+- `squashCommitMessage` is project-facing Git history for human readers.
+- Use `squashCommitMessage` only for `accept_complete`; when you return any non-accept action, set `squashCommitMessage` to null.
+- For `accept_complete`, provide a non-null object with one concise project-facing `subject` and 2 to 5 high-level `bullets`.
+- Do not mention plan paths, markdown plan filenames, temporary run paths, scope-numbered or per-scope wording, final cleanup, Neal mechanics, provider process, or reviewer process.
+- Summarize the code or product behavior change, not the plan document.
+- Valid example: subject "Persist final completion review failures"; bullets ["Mark invalid verdicts failed", "Record phase error events"].
+- Invalid example: subject "Finish scope 4 cleanup"; bullets ["Summarize per-scope plan work", "Describe reviewer process"].
+
+Coder whole-plan completion summary:
+{
+  "planGoalSatisfied": false,
+  "whatChangedOverall": "Canonical render matrix pinned across prompt specs.",
+  "verificationSummary": "pnpm typecheck",
+  "remainingKnownGaps": [
+    "One documentation pass remains."
+  ]
+}
+
+Whole-plan completion packet:
+{
+  "executionShape": "multi_scope",
+  "currentScopeLabel": "6",
+  "acceptedScopeRecordCount": 5,
+  "blockedScopeCount": 0,
+  "scopeAccountingSummary": "5 accepted top-level records",
+  "verificationOnlyCompletion": false,
+  "aggregateReviewContext": {
+    "baseCommit": "base000",
+    "headCommit": "head000",
+    "range": "base000..head000",
+    "commitSubjects": [
+      "head000 canonical render matrix"
+    ],
+    "diffStat": " src/example.ts | 2 +-",
+    "changedFiles": [
+      "src/example.ts"
+    ],
+    "unavailableReason": null
+  },
+  "finalCommit": "head000",
+  "completedScopeSummary": "1 accepted; 2 accepted",
+  "terminalChangedFilesSummary": "src/example.ts",
+  "planChangedFilesSummary": "src/example.ts",
+  "verificationTally": {
+    "totalRuns": 1,
+    "distinctCommands": 1,
+    "passed": 1,
+    "failed": 0,
+    "unknown": 0,
+    "recentFailures": []
+  },
+  "lastNonEmptyImplementationScope": {
+    "number": "5",
+    "finalCommit": "head000",
+    "commitSubject": "canonical render matrix",
+    "changedFiles": [
+      "src/example.ts"
+    ],
+    "archivedReviewPath": "/tmp/REVIEW-5.md"
+  },
+  "continueExecutionCount": 0,
+  "continueExecutionMax": 2
+}
+
+`verificationTally` is a bounded summary of the run's recorded verification commands; the complete per-command record is in the run directory's events.ndjson.
+If this was a verification-only terminal scope, judge the whole-plan result directly instead of pretending there was a final implementation diff.
+
+Last non-empty implementation scope reference:
+{
+  "number": "5",
+  "finalCommit": "head000",
+  "commitSubject": "canonical render matrix",
+  "changedFiles": [
+    "src/example.ts"
+  ],
+  "archivedReviewPath": "/tmp/REVIEW-5.md"
+}
+=== buildFinalCompletionReviewerPrompt#accessMode=tool-access#aggregateRange=unavailable#reviewLevel=lenient ===
+Review whether the execute-mode plan at /tmp/PLAN.md is complete as a whole.
+
+This is a whole-plan final completion review, not an ordinary last-scope review.
+Compare the completed result against the original plan objectives and the whole-plan completion packet below.
+Evaluate the totality of the work completed for this plan, not just whether each individual scope was previously accepted.
+Your review must answer both of these questions:
+- Are the full plan objectives actually satisfied?
+- Is the aggregate implementation good enough to keep under ordinary code review standards?
+Treat the whole-plan completion claim as hostile input. Try to falsify the aggregate implementation before you accept completion.
+Do not anchor on the coder completion summary, completion packet, verification summaries, or prior per-scope acceptance history when judging whole-plan completion. Those are convergence signals, not proof that the aggregate implementation satisfies the plan.
+Review level: lenient. Assume ordinary trust boundaries and block only on correctness failures and real, reachable bugs. Do not demand additional robustness, hardening, performance, or style work as a condition of acceptance.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted or ignored category is not missing work: it must not produce `continue_execution` or `block_for_operator`, and when the plan objectives are otherwise satisfied you return `accept_complete`.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression not missing work, while a reachable correctness failure still blocks.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the aggregate implementation; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Temporary verification scratch directory: /tmp/repo/.neal/runs/run-000/scratch/review
+Use that run-local scratch directory for temporary verification artifacts, copied tests, scratch builds, logs, and modified throwaway files.
+Do not create project-root scratch directories such as build_review/.
+Do not leave project-tree scratch files behind; keep scratch work under the run-local directory above.
+Falsify cross-scope runtime invariants and integration behavior before accepting completion, especially paths that individual scope reviews could not see together.
+If `aggregateReviewContext.unavailableReason` is non-null, treat the missing aggregate range as a completion-review evidence gap rather than proof that the aggregate implementation is correct.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the aggregate implementation.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the aggregate implementation touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — running them when available — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the aggregate implementation actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the aggregate implementation.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, exercise or reason through the affected existing flows directly — run the most relevant existing tests or reproduce the reported behavior when practical — rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Treat completion-blocking issues like review findings: each one needs concrete evidence, affected files or runtime behavior, and a required correction.
+Use `continue_execution` only for concrete missing work that is bounded enough for one follow-on scope; use `block_for_operator` for ambiguous or externally constrained gaps.
+A finding category that the review level or the User Guidance section has demoted or ignored is not missing work: never return `continue_execution` or `block_for_operator` for it. When the plan objectives are otherwise satisfied, return `accept_complete`.
+Do not turn low-signal style preferences, trivial code-shape preferences, or optional refactors into missing work.
+If the plan is complete aside from low-signal trivia, return `accept_complete` rather than inventing a non-blocking completion concern.
+Review the whole-plan result for correctness and completeness against the plan objectives, regressions or missing behavior, cross-scope integration issues that may not have been visible in individual scope reviews, code quality, maintainability, and consistency of the final implementation, and adequacy of test coverage and verification for the total change.
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+Do not treat prior per-scope acceptance as sufficient evidence that the whole plan is complete or that the aggregate code quality is acceptable.
+Return only JSON that matches the required schema.
+Return the final answer only as the required structured output object, not as prose or markdown.
+Defer exact output framing to the active structured-output transport; do not add your own output-format constraints.
+Use `accept_complete` only when the full plan objectives are satisfied and the aggregate implementation is acceptable under ordinary code review standards.
+Use `continue_execution` only when the remaining work is concrete, bounded, and suitable for one explicit follow-on scope.
+Use `block_for_operator` when the remaining gap is ambiguous, externally constrained, or needs human direction.
+When you return `continue_execution`, you must provide a non-null `missingWork` object with `summary`, `requiredOutcome`, and `verification`.
+When you return any other action, `missingWork` must be null.
+
+Squash commit message rules:
+- `squashCommitMessage` is project-facing Git history for human readers.
+- Use `squashCommitMessage` only for `accept_complete`; when you return any non-accept action, set `squashCommitMessage` to null.
+- For `accept_complete`, provide a non-null object with one concise project-facing `subject` and 2 to 5 high-level `bullets`.
+- Do not mention plan paths, markdown plan filenames, temporary run paths, scope-numbered or per-scope wording, final cleanup, Neal mechanics, provider process, or reviewer process.
+- Summarize the code or product behavior change, not the plan document.
+- Valid example: subject "Persist final completion review failures"; bullets ["Mark invalid verdicts failed", "Record phase error events"].
+- Invalid example: subject "Finish scope 4 cleanup"; bullets ["Summarize per-scope plan work", "Describe reviewer process"].
+
+Coder whole-plan completion summary:
+{
+  "planGoalSatisfied": false,
+  "whatChangedOverall": "Canonical render matrix pinned across prompt specs.",
+  "verificationSummary": "pnpm typecheck",
+  "remainingKnownGaps": [
+    "One documentation pass remains."
+  ]
+}
+
+Whole-plan completion packet:
+{
+  "executionShape": "multi_scope",
+  "currentScopeLabel": "6",
+  "acceptedScopeRecordCount": 5,
+  "blockedScopeCount": 0,
+  "scopeAccountingSummary": "5 accepted top-level records",
+  "verificationOnlyCompletion": false,
+  "aggregateReviewContext": {
+    "baseCommit": null,
+    "headCommit": null,
+    "range": null,
+    "commitSubjects": [],
+    "diffStat": "",
+    "changedFiles": [],
+    "unavailableReason": "no aggregate commit range was resolved"
+  },
+  "finalCommit": null,
+  "completedScopeSummary": "1 accepted; 2 accepted",
+  "terminalChangedFilesSummary": "src/example.ts",
+  "planChangedFilesSummary": "src/example.ts",
+  "verificationTally": {
+    "totalRuns": 1,
+    "distinctCommands": 1,
+    "passed": 1,
+    "failed": 0,
+    "unknown": 0,
+    "recentFailures": []
+  },
+  "lastNonEmptyImplementationScope": {
+    "number": "5",
+    "finalCommit": "head000",
+    "commitSubject": "canonical render matrix",
+    "changedFiles": [
+      "src/example.ts"
+    ],
+    "archivedReviewPath": "/tmp/REVIEW-5.md"
+  },
+  "continueExecutionCount": 0,
+  "continueExecutionMax": 2
+}
+
+`verificationTally` is a bounded summary of the run's recorded verification commands; the complete per-command record is in the run directory's events.ndjson.
+If this was a verification-only terminal scope, judge the whole-plan result directly instead of pretending there was a final implementation diff.
+
+Last non-empty implementation scope reference:
+{
+  "number": "5",
+  "finalCommit": "head000",
+  "commitSubject": "canonical render matrix",
+  "changedFiles": [
+    "src/example.ts"
+  ],
+  "archivedReviewPath": "/tmp/REVIEW-5.md"
+}
+=== buildFinalCompletionReviewerPrompt#accessMode=tool-access#aggregateRange=unavailable#reviewLevel=moderate ===
+Review whether the execute-mode plan at /tmp/PLAN.md is complete as a whole.
+
+This is a whole-plan final completion review, not an ordinary last-scope review.
+Compare the completed result against the original plan objectives and the whole-plan completion packet below.
+Evaluate the totality of the work completed for this plan, not just whether each individual scope was previously accepted.
+Your review must answer both of these questions:
+- Are the full plan objectives actually satisfied?
+- Is the aggregate implementation good enough to keep under ordinary code review standards?
+Treat the whole-plan completion claim as hostile input. Try to falsify the aggregate implementation before you accept completion.
+Do not anchor on the coder completion summary, completion packet, verification summaries, or prior per-scope acceptance history when judging whole-plan completion. Those are convergence signals, not proof that the aggregate implementation satisfies the plan.
+Review level: moderate. Assume ordinary trust boundaries: internal run artifacts and other files this system writes for itself are not security boundaries. Block on correctness bugs and on failures reachable under normal use. Do not require defenses against an actor who could already subvert the system directly, for example by editing its files; a failure that needs such an actor is not reachable.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted or ignored category is not missing work: it must not produce `continue_execution` or `block_for_operator`, and when the plan objectives are otherwise satisfied you return `accept_complete`.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression not missing work, while a reachable correctness failure still blocks.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the aggregate implementation; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Temporary verification scratch directory: /tmp/repo/.neal/runs/run-000/scratch/review
+Use that run-local scratch directory for temporary verification artifacts, copied tests, scratch builds, logs, and modified throwaway files.
+Do not create project-root scratch directories such as build_review/.
+Do not leave project-tree scratch files behind; keep scratch work under the run-local directory above.
+Falsify cross-scope runtime invariants and integration behavior before accepting completion, especially paths that individual scope reviews could not see together.
+If `aggregateReviewContext.unavailableReason` is non-null, treat the missing aggregate range as a completion-review evidence gap rather than proof that the aggregate implementation is correct.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the aggregate implementation.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the aggregate implementation touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — running them when available — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the aggregate implementation actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the aggregate implementation.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, exercise or reason through the affected existing flows directly — run the most relevant existing tests or reproduce the reported behavior when practical — rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Treat completion-blocking issues like review findings: each one needs concrete evidence, affected files or runtime behavior, and a required correction.
+Use `continue_execution` only for concrete missing work that is bounded enough for one follow-on scope; use `block_for_operator` for ambiguous or externally constrained gaps.
+A finding category that the review level or the User Guidance section has demoted or ignored is not missing work: never return `continue_execution` or `block_for_operator` for it. When the plan objectives are otherwise satisfied, return `accept_complete`.
+Do not turn low-signal style preferences, trivial code-shape preferences, or optional refactors into missing work.
+If the plan is complete aside from low-signal trivia, return `accept_complete` rather than inventing a non-blocking completion concern.
+Review the whole-plan result for correctness and completeness against the plan objectives, regressions or missing behavior, cross-scope integration issues that may not have been visible in individual scope reviews, code quality, maintainability, and consistency of the final implementation, and adequacy of test coverage and verification for the total change.
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+Do not treat prior per-scope acceptance as sufficient evidence that the whole plan is complete or that the aggregate code quality is acceptable.
+Return only JSON that matches the required schema.
+Return the final answer only as the required structured output object, not as prose or markdown.
+Defer exact output framing to the active structured-output transport; do not add your own output-format constraints.
+Use `accept_complete` only when the full plan objectives are satisfied and the aggregate implementation is acceptable under ordinary code review standards.
+Use `continue_execution` only when the remaining work is concrete, bounded, and suitable for one explicit follow-on scope.
+Use `block_for_operator` when the remaining gap is ambiguous, externally constrained, or needs human direction.
+When you return `continue_execution`, you must provide a non-null `missingWork` object with `summary`, `requiredOutcome`, and `verification`.
+When you return any other action, `missingWork` must be null.
+
+Squash commit message rules:
+- `squashCommitMessage` is project-facing Git history for human readers.
+- Use `squashCommitMessage` only for `accept_complete`; when you return any non-accept action, set `squashCommitMessage` to null.
+- For `accept_complete`, provide a non-null object with one concise project-facing `subject` and 2 to 5 high-level `bullets`.
+- Do not mention plan paths, markdown plan filenames, temporary run paths, scope-numbered or per-scope wording, final cleanup, Neal mechanics, provider process, or reviewer process.
+- Summarize the code or product behavior change, not the plan document.
+- Valid example: subject "Persist final completion review failures"; bullets ["Mark invalid verdicts failed", "Record phase error events"].
+- Invalid example: subject "Finish scope 4 cleanup"; bullets ["Summarize per-scope plan work", "Describe reviewer process"].
+
+Coder whole-plan completion summary:
+{
+  "planGoalSatisfied": false,
+  "whatChangedOverall": "Canonical render matrix pinned across prompt specs.",
+  "verificationSummary": "pnpm typecheck",
+  "remainingKnownGaps": [
+    "One documentation pass remains."
+  ]
+}
+
+Whole-plan completion packet:
+{
+  "executionShape": "multi_scope",
+  "currentScopeLabel": "6",
+  "acceptedScopeRecordCount": 5,
+  "blockedScopeCount": 0,
+  "scopeAccountingSummary": "5 accepted top-level records",
+  "verificationOnlyCompletion": false,
+  "aggregateReviewContext": {
+    "baseCommit": null,
+    "headCommit": null,
+    "range": null,
+    "commitSubjects": [],
+    "diffStat": "",
+    "changedFiles": [],
+    "unavailableReason": "no aggregate commit range was resolved"
+  },
+  "finalCommit": null,
+  "completedScopeSummary": "1 accepted; 2 accepted",
+  "terminalChangedFilesSummary": "src/example.ts",
+  "planChangedFilesSummary": "src/example.ts",
+  "verificationTally": {
+    "totalRuns": 1,
+    "distinctCommands": 1,
+    "passed": 1,
+    "failed": 0,
+    "unknown": 0,
+    "recentFailures": []
+  },
+  "lastNonEmptyImplementationScope": {
+    "number": "5",
+    "finalCommit": "head000",
+    "commitSubject": "canonical render matrix",
+    "changedFiles": [
+      "src/example.ts"
+    ],
+    "archivedReviewPath": "/tmp/REVIEW-5.md"
+  },
+  "continueExecutionCount": 0,
+  "continueExecutionMax": 2
+}
+
+`verificationTally` is a bounded summary of the run's recorded verification commands; the complete per-command record is in the run directory's events.ndjson.
+If this was a verification-only terminal scope, judge the whole-plan result directly instead of pretending there was a final implementation diff.
+
+Last non-empty implementation scope reference:
+{
+  "number": "5",
+  "finalCommit": "head000",
+  "commitSubject": "canonical render matrix",
+  "changedFiles": [
+    "src/example.ts"
+  ],
+  "archivedReviewPath": "/tmp/REVIEW-5.md"
+}
+=== buildFinalCompletionReviewerPrompt#accessMode=tool-access#aggregateRange=unavailable#reviewLevel=strict ===
+Review whether the execute-mode plan at /tmp/PLAN.md is complete as a whole.
+
+This is a whole-plan final completion review, not an ordinary last-scope review.
+Compare the completed result against the original plan objectives and the whole-plan completion packet below.
+Evaluate the totality of the work completed for this plan, not just whether each individual scope was previously accepted.
+Your review must answer both of these questions:
+- Are the full plan objectives actually satisfied?
+- Is the aggregate implementation good enough to keep under ordinary code review standards?
+Treat the whole-plan completion claim as hostile input. Try to falsify the aggregate implementation before you accept completion.
+Do not anchor on the coder completion summary, completion packet, verification summaries, or prior per-scope acceptance history when judging whole-plan completion. Those are convergence signals, not proof that the aggregate implementation satisfies the plan.
+Review level: strict. Assume adversarial trust boundaries: treat every input, file, and process the change can be reached from, including local processes and internal run artifacts, as a potential attacker. A hardening gap or a missing defense against a local or adversarial actor is a reachable failure under these boundaries and blocks.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted or ignored category is not missing work: it must not produce `continue_execution` or `block_for_operator`, and when the plan objectives are otherwise satisfied you return `accept_complete`.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression not missing work, while a reachable correctness failure still blocks.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the aggregate implementation; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Temporary verification scratch directory: /tmp/repo/.neal/runs/run-000/scratch/review
+Use that run-local scratch directory for temporary verification artifacts, copied tests, scratch builds, logs, and modified throwaway files.
+Do not create project-root scratch directories such as build_review/.
+Do not leave project-tree scratch files behind; keep scratch work under the run-local directory above.
+Falsify cross-scope runtime invariants and integration behavior before accepting completion, especially paths that individual scope reviews could not see together.
+If `aggregateReviewContext.unavailableReason` is non-null, treat the missing aggregate range as a completion-review evidence gap rather than proof that the aggregate implementation is correct.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the aggregate implementation.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the aggregate implementation touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — running them when available — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the aggregate implementation actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the aggregate implementation.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, exercise or reason through the affected existing flows directly — run the most relevant existing tests or reproduce the reported behavior when practical — rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Treat completion-blocking issues like review findings: each one needs concrete evidence, affected files or runtime behavior, and a required correction.
+Use `continue_execution` only for concrete missing work that is bounded enough for one follow-on scope; use `block_for_operator` for ambiguous or externally constrained gaps.
+A finding category that the review level or the User Guidance section has demoted or ignored is not missing work: never return `continue_execution` or `block_for_operator` for it. When the plan objectives are otherwise satisfied, return `accept_complete`.
+Do not turn low-signal style preferences, trivial code-shape preferences, or optional refactors into missing work.
+If the plan is complete aside from low-signal trivia, return `accept_complete` rather than inventing a non-blocking completion concern.
+Review the whole-plan result for correctness and completeness against the plan objectives, regressions or missing behavior, cross-scope integration issues that may not have been visible in individual scope reviews, code quality, maintainability, and consistency of the final implementation, and adequacy of test coverage and verification for the total change.
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+Do not treat prior per-scope acceptance as sufficient evidence that the whole plan is complete or that the aggregate code quality is acceptable.
+Return only JSON that matches the required schema.
+Return the final answer only as the required structured output object, not as prose or markdown.
+Defer exact output framing to the active structured-output transport; do not add your own output-format constraints.
+Use `accept_complete` only when the full plan objectives are satisfied and the aggregate implementation is acceptable under ordinary code review standards.
+Use `continue_execution` only when the remaining work is concrete, bounded, and suitable for one explicit follow-on scope.
+Use `block_for_operator` when the remaining gap is ambiguous, externally constrained, or needs human direction.
+When you return `continue_execution`, you must provide a non-null `missingWork` object with `summary`, `requiredOutcome`, and `verification`.
+When you return any other action, `missingWork` must be null.
+
+Squash commit message rules:
+- `squashCommitMessage` is project-facing Git history for human readers.
+- Use `squashCommitMessage` only for `accept_complete`; when you return any non-accept action, set `squashCommitMessage` to null.
+- For `accept_complete`, provide a non-null object with one concise project-facing `subject` and 2 to 5 high-level `bullets`.
+- Do not mention plan paths, markdown plan filenames, temporary run paths, scope-numbered or per-scope wording, final cleanup, Neal mechanics, provider process, or reviewer process.
+- Summarize the code or product behavior change, not the plan document.
+- Valid example: subject "Persist final completion review failures"; bullets ["Mark invalid verdicts failed", "Record phase error events"].
+- Invalid example: subject "Finish scope 4 cleanup"; bullets ["Summarize per-scope plan work", "Describe reviewer process"].
+
+Coder whole-plan completion summary:
+{
+  "planGoalSatisfied": false,
+  "whatChangedOverall": "Canonical render matrix pinned across prompt specs.",
+  "verificationSummary": "pnpm typecheck",
+  "remainingKnownGaps": [
+    "One documentation pass remains."
+  ]
+}
+
+Whole-plan completion packet:
+{
+  "executionShape": "multi_scope",
+  "currentScopeLabel": "6",
+  "acceptedScopeRecordCount": 5,
+  "blockedScopeCount": 0,
+  "scopeAccountingSummary": "5 accepted top-level records",
+  "verificationOnlyCompletion": false,
+  "aggregateReviewContext": {
+    "baseCommit": null,
+    "headCommit": null,
+    "range": null,
+    "commitSubjects": [],
+    "diffStat": "",
+    "changedFiles": [],
+    "unavailableReason": "no aggregate commit range was resolved"
+  },
+  "finalCommit": null,
+  "completedScopeSummary": "1 accepted; 2 accepted",
+  "terminalChangedFilesSummary": "src/example.ts",
+  "planChangedFilesSummary": "src/example.ts",
+  "verificationTally": {
+    "totalRuns": 1,
+    "distinctCommands": 1,
+    "passed": 1,
+    "failed": 0,
+    "unknown": 0,
+    "recentFailures": []
+  },
+  "lastNonEmptyImplementationScope": {
+    "number": "5",
+    "finalCommit": "head000",
+    "commitSubject": "canonical render matrix",
+    "changedFiles": [
+      "src/example.ts"
+    ],
+    "archivedReviewPath": "/tmp/REVIEW-5.md"
+  },
+  "continueExecutionCount": 0,
+  "continueExecutionMax": 2
+}
+
+`verificationTally` is a bounded summary of the run's recorded verification commands; the complete per-command record is in the run directory's events.ndjson.
+If this was a verification-only terminal scope, judge the whole-plan result directly instead of pretending there was a final implementation diff.
+
+Last non-empty implementation scope reference:
+{
+  "number": "5",
+  "finalCommit": "head000",
+  "commitSubject": "canonical render matrix",
+  "changedFiles": [
+    "src/example.ts"
+  ],
+  "archivedReviewPath": "/tmp/REVIEW-5.md"
+}

--- a/test/fixtures/prompts/render-integrity/scope_reviewer.v6.txt
+++ b/test/fixtures/prompts/render-integrity/scope_reviewer.v6.txt
@@ -1,0 +1,4746 @@
+=== buildReviewerPrompt#accessMode=read-only-inlined#earlierScopeChanges=absent#previousHead=absent#reviewLevel=lenient ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+The commit-range diff for that commit range is inlined below and is the source of truth for exactly what the commit range changed (including deletions and renames). Use your read tools to verify the surrounding code; you have no commit-range diff tool, so rely on the inlined diff for what changed.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Your read tools may be dedicated read and search tools, or a shell running in a read-only sandbox. If your only repository tool is that shell, use it to read files and search the tree (for example cat, sed -n, grep, ls); it cannot write, and you must not try to.
+Inspect the change using the inlined commit-range diff below for what changed (including deletions and renames), then read the changed files in full with your read tools and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: lenient. Assume ordinary trust boundaries and block only on correctness failures and real, reachable bugs. Do not demand additional robustness, hardening, performance, or style work as a condition of acceptance.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Robustness or performance regressions introduced by the implementation are non_blocking unless they are a reachable correctness failure; use blocking severity only in that case.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+This is the first reviewer round for this scope.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+
+## Inlined commit-range diff from Neal (base000..head000)
+
+You have read-only repository access but no commit-range diff tool, so Neal has inlined the commit-range diff below. That access may be dedicated read and search tools, or a shell running in a read-only sandbox; if it is a shell, use it only to read files and search the tree, never to write.
+This inlined diff is the source of truth for exactly what this range changed, including deletions and renames that head-state file reads cannot reveal. Use your read tools to verify the surrounding code.
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-old
++new
+
+=== buildReviewerPrompt#accessMode=read-only-inlined#earlierScopeChanges=absent#previousHead=absent#reviewLevel=moderate ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+The commit-range diff for that commit range is inlined below and is the source of truth for exactly what the commit range changed (including deletions and renames). Use your read tools to verify the surrounding code; you have no commit-range diff tool, so rely on the inlined diff for what changed.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Your read tools may be dedicated read and search tools, or a shell running in a read-only sandbox. If your only repository tool is that shell, use it to read files and search the tree (for example cat, sed -n, grep, ls); it cannot write, and you must not try to.
+Inspect the change using the inlined commit-range diff below for what changed (including deletions and renames), then read the changed files in full with your read tools and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: moderate. Assume ordinary trust boundaries: internal run artifacts and other files this system writes for itself are not security boundaries. Block on correctness bugs and on failures reachable under normal use. Do not require defenses against an actor who could already subvert the system directly, for example by editing its files; a failure that needs such an actor is not reachable.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+This is the first reviewer round for this scope.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+
+## Inlined commit-range diff from Neal (base000..head000)
+
+You have read-only repository access but no commit-range diff tool, so Neal has inlined the commit-range diff below. That access may be dedicated read and search tools, or a shell running in a read-only sandbox; if it is a shell, use it only to read files and search the tree, never to write.
+This inlined diff is the source of truth for exactly what this range changed, including deletions and renames that head-state file reads cannot reveal. Use your read tools to verify the surrounding code.
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-old
++new
+
+=== buildReviewerPrompt#accessMode=read-only-inlined#earlierScopeChanges=absent#previousHead=absent#reviewLevel=strict ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+The commit-range diff for that commit range is inlined below and is the source of truth for exactly what the commit range changed (including deletions and renames). Use your read tools to verify the surrounding code; you have no commit-range diff tool, so rely on the inlined diff for what changed.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Your read tools may be dedicated read and search tools, or a shell running in a read-only sandbox. If your only repository tool is that shell, use it to read files and search the tree (for example cat, sed -n, grep, ls); it cannot write, and you must not try to.
+Inspect the change using the inlined commit-range diff below for what changed (including deletions and renames), then read the changed files in full with your read tools and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: strict. Assume adversarial trust boundaries: treat every input, file, and process the change can be reached from, including local processes and internal run artifacts, as a potential attacker. A hardening gap or a missing defense against a local or adversarial actor is a reachable failure under these boundaries and blocks.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+This is the first reviewer round for this scope.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+
+## Inlined commit-range diff from Neal (base000..head000)
+
+You have read-only repository access but no commit-range diff tool, so Neal has inlined the commit-range diff below. That access may be dedicated read and search tools, or a shell running in a read-only sandbox; if it is a shell, use it only to read files and search the tree, never to write.
+This inlined diff is the source of truth for exactly what this range changed, including deletions and renames that head-state file reads cannot reveal. Use your read tools to verify the surrounding code.
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-old
++new
+
+=== buildReviewerPrompt#accessMode=read-only-inlined#earlierScopeChanges=absent#previousHead=present#reviewLevel=lenient ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+The commit-range diff for that commit range is inlined below and is the source of truth for exactly what the commit range changed (including deletions and renames). Use your read tools to verify the surrounding code; you have no commit-range diff tool, so rely on the inlined diff for what changed.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Your read tools may be dedicated read and search tools, or a shell running in a read-only sandbox. If your only repository tool is that shell, use it to read files and search the tree (for example cat, sed -n, grep, ls); it cannot write, and you must not try to.
+Inspect the change using the inlined commit-range diff below for what changed (including deletions and renames), then read the changed files in full with your read tools and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: lenient. Assume ordinary trust boundaries and block only on correctness failures and real, reachable bugs. Do not demand additional robustness, hardening, performance, or style work as a condition of acceptance.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Robustness or performance regressions introduced by the implementation are non_blocking unless they are a reachable correctness failure; use blocking severity only in that case.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Previous reviewer head was prevhead000. Focus especially on changes since that commit, while still considering the full current state.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+
+## Inlined commit-range diff from Neal (base000..head000)
+
+You have read-only repository access but no commit-range diff tool, so Neal has inlined the commit-range diff below. That access may be dedicated read and search tools, or a shell running in a read-only sandbox; if it is a shell, use it only to read files and search the tree, never to write.
+This inlined diff is the source of truth for exactly what this range changed, including deletions and renames that head-state file reads cannot reveal. Use your read tools to verify the surrounding code.
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-old
++new
+
+=== buildReviewerPrompt#accessMode=read-only-inlined#earlierScopeChanges=absent#previousHead=present#reviewLevel=moderate ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+The commit-range diff for that commit range is inlined below and is the source of truth for exactly what the commit range changed (including deletions and renames). Use your read tools to verify the surrounding code; you have no commit-range diff tool, so rely on the inlined diff for what changed.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Your read tools may be dedicated read and search tools, or a shell running in a read-only sandbox. If your only repository tool is that shell, use it to read files and search the tree (for example cat, sed -n, grep, ls); it cannot write, and you must not try to.
+Inspect the change using the inlined commit-range diff below for what changed (including deletions and renames), then read the changed files in full with your read tools and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: moderate. Assume ordinary trust boundaries: internal run artifacts and other files this system writes for itself are not security boundaries. Block on correctness bugs and on failures reachable under normal use. Do not require defenses against an actor who could already subvert the system directly, for example by editing its files; a failure that needs such an actor is not reachable.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Previous reviewer head was prevhead000. Focus especially on changes since that commit, while still considering the full current state.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+
+## Inlined commit-range diff from Neal (base000..head000)
+
+You have read-only repository access but no commit-range diff tool, so Neal has inlined the commit-range diff below. That access may be dedicated read and search tools, or a shell running in a read-only sandbox; if it is a shell, use it only to read files and search the tree, never to write.
+This inlined diff is the source of truth for exactly what this range changed, including deletions and renames that head-state file reads cannot reveal. Use your read tools to verify the surrounding code.
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-old
++new
+
+=== buildReviewerPrompt#accessMode=read-only-inlined#earlierScopeChanges=absent#previousHead=present#reviewLevel=strict ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+The commit-range diff for that commit range is inlined below and is the source of truth for exactly what the commit range changed (including deletions and renames). Use your read tools to verify the surrounding code; you have no commit-range diff tool, so rely on the inlined diff for what changed.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Your read tools may be dedicated read and search tools, or a shell running in a read-only sandbox. If your only repository tool is that shell, use it to read files and search the tree (for example cat, sed -n, grep, ls); it cannot write, and you must not try to.
+Inspect the change using the inlined commit-range diff below for what changed (including deletions and renames), then read the changed files in full with your read tools and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: strict. Assume adversarial trust boundaries: treat every input, file, and process the change can be reached from, including local processes and internal run artifacts, as a potential attacker. A hardening gap or a missing defense against a local or adversarial actor is a reachable failure under these boundaries and blocks.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Previous reviewer head was prevhead000. Focus especially on changes since that commit, while still considering the full current state.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+
+## Inlined commit-range diff from Neal (base000..head000)
+
+You have read-only repository access but no commit-range diff tool, so Neal has inlined the commit-range diff below. That access may be dedicated read and search tools, or a shell running in a read-only sandbox; if it is a shell, use it only to read files and search the tree, never to write.
+This inlined diff is the source of truth for exactly what this range changed, including deletions and renames that head-state file reads cannot reveal. Use your read tools to verify the surrounding code.
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-old
++new
+
+=== buildReviewerPrompt#accessMode=read-only-inlined#earlierScopeChanges=present#previousHead=absent#reviewLevel=lenient ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+The commit-range diff for that commit range is inlined below and is the source of truth for exactly what the commit range changed (including deletions and renames). Use your read tools to verify the surrounding code; you have no commit-range diff tool, so rely on the inlined diff for what changed.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Your read tools may be dedicated read and search tools, or a shell running in a read-only sandbox. If your only repository tool is that shell, use it to read files and search the tree (for example cat, sed -n, grep, ls); it cannot write, and you must not try to.
+Inspect the change using the inlined commit-range diff below for what changed (including deletions and renames), then read the changed files in full with your read tools and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: lenient. Assume ordinary trust boundaries and block only on correctness failures and real, reachable bugs. Do not demand additional robustness, hardening, performance, or style work as a condition of acceptance.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Robustness or performance regressions introduced by the implementation are non_blocking unless they are a reachable correctness failure; use blocking severity only in that case.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+This is the first reviewer round for this scope.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+
+## Inlined commit-range diff from Neal (base000..head000)
+
+You have read-only repository access but no commit-range diff tool, so Neal has inlined the commit-range diff below. That access may be dedicated read and search tools, or a shell running in a read-only sandbox; if it is a shell, use it only to read files and search the tree, never to write.
+This inlined diff is the source of truth for exactly what this range changed, including deletions and renames that head-state file reads cannot reveal. Use your read tools to verify the surrounding code.
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-old
++new
+
+
+## Earlier-scope changes to files in this diff
+
+The files below were changed by an earlier accepted scope in this run and appear again in the current diff. Each entry shows what that earlier scope did to the file, so what the current scope alters is something you read here rather than something you have to remember.
+Check the current diff against each entry before accepting.
+
+### src/example.ts (scope 3, scope3base000..scope3final000)
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-older
++old
+
+=== buildReviewerPrompt#accessMode=read-only-inlined#earlierScopeChanges=present#previousHead=absent#reviewLevel=moderate ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+The commit-range diff for that commit range is inlined below and is the source of truth for exactly what the commit range changed (including deletions and renames). Use your read tools to verify the surrounding code; you have no commit-range diff tool, so rely on the inlined diff for what changed.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Your read tools may be dedicated read and search tools, or a shell running in a read-only sandbox. If your only repository tool is that shell, use it to read files and search the tree (for example cat, sed -n, grep, ls); it cannot write, and you must not try to.
+Inspect the change using the inlined commit-range diff below for what changed (including deletions and renames), then read the changed files in full with your read tools and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: moderate. Assume ordinary trust boundaries: internal run artifacts and other files this system writes for itself are not security boundaries. Block on correctness bugs and on failures reachable under normal use. Do not require defenses against an actor who could already subvert the system directly, for example by editing its files; a failure that needs such an actor is not reachable.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+This is the first reviewer round for this scope.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+
+## Inlined commit-range diff from Neal (base000..head000)
+
+You have read-only repository access but no commit-range diff tool, so Neal has inlined the commit-range diff below. That access may be dedicated read and search tools, or a shell running in a read-only sandbox; if it is a shell, use it only to read files and search the tree, never to write.
+This inlined diff is the source of truth for exactly what this range changed, including deletions and renames that head-state file reads cannot reveal. Use your read tools to verify the surrounding code.
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-old
++new
+
+
+## Earlier-scope changes to files in this diff
+
+The files below were changed by an earlier accepted scope in this run and appear again in the current diff. Each entry shows what that earlier scope did to the file, so what the current scope alters is something you read here rather than something you have to remember.
+Check the current diff against each entry before accepting.
+
+### src/example.ts (scope 3, scope3base000..scope3final000)
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-older
++old
+
+=== buildReviewerPrompt#accessMode=read-only-inlined#earlierScopeChanges=present#previousHead=absent#reviewLevel=strict ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+The commit-range diff for that commit range is inlined below and is the source of truth for exactly what the commit range changed (including deletions and renames). Use your read tools to verify the surrounding code; you have no commit-range diff tool, so rely on the inlined diff for what changed.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Your read tools may be dedicated read and search tools, or a shell running in a read-only sandbox. If your only repository tool is that shell, use it to read files and search the tree (for example cat, sed -n, grep, ls); it cannot write, and you must not try to.
+Inspect the change using the inlined commit-range diff below for what changed (including deletions and renames), then read the changed files in full with your read tools and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: strict. Assume adversarial trust boundaries: treat every input, file, and process the change can be reached from, including local processes and internal run artifacts, as a potential attacker. A hardening gap or a missing defense against a local or adversarial actor is a reachable failure under these boundaries and blocks.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+This is the first reviewer round for this scope.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+
+## Inlined commit-range diff from Neal (base000..head000)
+
+You have read-only repository access but no commit-range diff tool, so Neal has inlined the commit-range diff below. That access may be dedicated read and search tools, or a shell running in a read-only sandbox; if it is a shell, use it only to read files and search the tree, never to write.
+This inlined diff is the source of truth for exactly what this range changed, including deletions and renames that head-state file reads cannot reveal. Use your read tools to verify the surrounding code.
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-old
++new
+
+
+## Earlier-scope changes to files in this diff
+
+The files below were changed by an earlier accepted scope in this run and appear again in the current diff. Each entry shows what that earlier scope did to the file, so what the current scope alters is something you read here rather than something you have to remember.
+Check the current diff against each entry before accepting.
+
+### src/example.ts (scope 3, scope3base000..scope3final000)
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-older
++old
+
+=== buildReviewerPrompt#accessMode=read-only-inlined#earlierScopeChanges=present#previousHead=present#reviewLevel=lenient ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+The commit-range diff for that commit range is inlined below and is the source of truth for exactly what the commit range changed (including deletions and renames). Use your read tools to verify the surrounding code; you have no commit-range diff tool, so rely on the inlined diff for what changed.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Your read tools may be dedicated read and search tools, or a shell running in a read-only sandbox. If your only repository tool is that shell, use it to read files and search the tree (for example cat, sed -n, grep, ls); it cannot write, and you must not try to.
+Inspect the change using the inlined commit-range diff below for what changed (including deletions and renames), then read the changed files in full with your read tools and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: lenient. Assume ordinary trust boundaries and block only on correctness failures and real, reachable bugs. Do not demand additional robustness, hardening, performance, or style work as a condition of acceptance.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Robustness or performance regressions introduced by the implementation are non_blocking unless they are a reachable correctness failure; use blocking severity only in that case.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Previous reviewer head was prevhead000. Focus especially on changes since that commit, while still considering the full current state.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+
+## Inlined commit-range diff from Neal (base000..head000)
+
+You have read-only repository access but no commit-range diff tool, so Neal has inlined the commit-range diff below. That access may be dedicated read and search tools, or a shell running in a read-only sandbox; if it is a shell, use it only to read files and search the tree, never to write.
+This inlined diff is the source of truth for exactly what this range changed, including deletions and renames that head-state file reads cannot reveal. Use your read tools to verify the surrounding code.
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-old
++new
+
+
+## Earlier-scope changes to files in this diff
+
+The files below were changed by an earlier accepted scope in this run and appear again in the current diff. Each entry shows what that earlier scope did to the file, so what the current scope alters is something you read here rather than something you have to remember.
+Check the current diff against each entry before accepting.
+
+### src/example.ts (scope 3, scope3base000..scope3final000)
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-older
++old
+
+=== buildReviewerPrompt#accessMode=read-only-inlined#earlierScopeChanges=present#previousHead=present#reviewLevel=moderate ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+The commit-range diff for that commit range is inlined below and is the source of truth for exactly what the commit range changed (including deletions and renames). Use your read tools to verify the surrounding code; you have no commit-range diff tool, so rely on the inlined diff for what changed.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Your read tools may be dedicated read and search tools, or a shell running in a read-only sandbox. If your only repository tool is that shell, use it to read files and search the tree (for example cat, sed -n, grep, ls); it cannot write, and you must not try to.
+Inspect the change using the inlined commit-range diff below for what changed (including deletions and renames), then read the changed files in full with your read tools and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: moderate. Assume ordinary trust boundaries: internal run artifacts and other files this system writes for itself are not security boundaries. Block on correctness bugs and on failures reachable under normal use. Do not require defenses against an actor who could already subvert the system directly, for example by editing its files; a failure that needs such an actor is not reachable.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Previous reviewer head was prevhead000. Focus especially on changes since that commit, while still considering the full current state.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+
+## Inlined commit-range diff from Neal (base000..head000)
+
+You have read-only repository access but no commit-range diff tool, so Neal has inlined the commit-range diff below. That access may be dedicated read and search tools, or a shell running in a read-only sandbox; if it is a shell, use it only to read files and search the tree, never to write.
+This inlined diff is the source of truth for exactly what this range changed, including deletions and renames that head-state file reads cannot reveal. Use your read tools to verify the surrounding code.
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-old
++new
+
+
+## Earlier-scope changes to files in this diff
+
+The files below were changed by an earlier accepted scope in this run and appear again in the current diff. Each entry shows what that earlier scope did to the file, so what the current scope alters is something you read here rather than something you have to remember.
+Check the current diff against each entry before accepting.
+
+### src/example.ts (scope 3, scope3base000..scope3final000)
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-older
++old
+
+=== buildReviewerPrompt#accessMode=read-only-inlined#earlierScopeChanges=present#previousHead=present#reviewLevel=strict ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+The commit-range diff for that commit range is inlined below and is the source of truth for exactly what the commit range changed (including deletions and renames). Use your read tools to verify the surrounding code; you have no commit-range diff tool, so rely on the inlined diff for what changed.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Your read tools may be dedicated read and search tools, or a shell running in a read-only sandbox. If your only repository tool is that shell, use it to read files and search the tree (for example cat, sed -n, grep, ls); it cannot write, and you must not try to.
+Inspect the change using the inlined commit-range diff below for what changed (including deletions and renames), then read the changed files in full with your read tools and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: strict. Assume adversarial trust boundaries: treat every input, file, and process the change can be reached from, including local processes and internal run artifacts, as a potential attacker. A hardening gap or a missing defense against a local or adversarial actor is a reachable failure under these boundaries and blocks.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Previous reviewer head was prevhead000. Focus especially on changes since that commit, while still considering the full current state.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+
+## Inlined commit-range diff from Neal (base000..head000)
+
+You have read-only repository access but no commit-range diff tool, so Neal has inlined the commit-range diff below. That access may be dedicated read and search tools, or a shell running in a read-only sandbox; if it is a shell, use it only to read files and search the tree, never to write.
+This inlined diff is the source of truth for exactly what this range changed, including deletions and renames that head-state file reads cannot reveal. Use your read tools to verify the surrounding code.
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-old
++new
+
+
+## Earlier-scope changes to files in this diff
+
+The files below were changed by an earlier accepted scope in this run and appear again in the current diff. Each entry shows what that earlier scope did to the file, so what the current scope alters is something you read here rather than something you have to remember.
+Check the current diff against each entry before accepting.
+
+### src/example.ts (scope 3, scope3base000..scope3final000)
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-older
++old
+
+=== buildReviewerPrompt#accessMode=read-only-tool#earlierScopeChanges=absent#previousHead=absent#reviewLevel=lenient ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+Review that commit range directly with your read-only repository tools: use the git_diff tool to see exactly what the commit range changed (including deletions and renames), and your read tools to verify the surrounding code. The commit range is the source of truth for this review.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Your read tools may be dedicated read and search tools, or a shell running in a read-only sandbox. If your only repository tool is that shell, use it to read files and search the tree (for example cat, sed -n, grep, ls); it cannot write, and you must not try to.
+Inspect the change with your read-only tools: call git_diff with the base and head commits named in this prompt (stat:true first for the changed-file overview, then per-path diffs), read the changed files in full, and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: lenient. Assume ordinary trust boundaries and block only on correctness failures and real, reachable bugs. Do not demand additional robustness, hardening, performance, or style work as a condition of acceptance.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Robustness or performance regressions introduced by the implementation are non_blocking unless they are a reachable correctness failure; use blocking severity only in that case.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+This is the first reviewer round for this scope.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+=== buildReviewerPrompt#accessMode=read-only-tool#earlierScopeChanges=absent#previousHead=absent#reviewLevel=moderate ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+Review that commit range directly with your read-only repository tools: use the git_diff tool to see exactly what the commit range changed (including deletions and renames), and your read tools to verify the surrounding code. The commit range is the source of truth for this review.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Your read tools may be dedicated read and search tools, or a shell running in a read-only sandbox. If your only repository tool is that shell, use it to read files and search the tree (for example cat, sed -n, grep, ls); it cannot write, and you must not try to.
+Inspect the change with your read-only tools: call git_diff with the base and head commits named in this prompt (stat:true first for the changed-file overview, then per-path diffs), read the changed files in full, and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: moderate. Assume ordinary trust boundaries: internal run artifacts and other files this system writes for itself are not security boundaries. Block on correctness bugs and on failures reachable under normal use. Do not require defenses against an actor who could already subvert the system directly, for example by editing its files; a failure that needs such an actor is not reachable.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+This is the first reviewer round for this scope.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+=== buildReviewerPrompt#accessMode=read-only-tool#earlierScopeChanges=absent#previousHead=absent#reviewLevel=strict ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+Review that commit range directly with your read-only repository tools: use the git_diff tool to see exactly what the commit range changed (including deletions and renames), and your read tools to verify the surrounding code. The commit range is the source of truth for this review.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Your read tools may be dedicated read and search tools, or a shell running in a read-only sandbox. If your only repository tool is that shell, use it to read files and search the tree (for example cat, sed -n, grep, ls); it cannot write, and you must not try to.
+Inspect the change with your read-only tools: call git_diff with the base and head commits named in this prompt (stat:true first for the changed-file overview, then per-path diffs), read the changed files in full, and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: strict. Assume adversarial trust boundaries: treat every input, file, and process the change can be reached from, including local processes and internal run artifacts, as a potential attacker. A hardening gap or a missing defense against a local or adversarial actor is a reachable failure under these boundaries and blocks.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+This is the first reviewer round for this scope.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+=== buildReviewerPrompt#accessMode=read-only-tool#earlierScopeChanges=absent#previousHead=present#reviewLevel=lenient ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+Review that commit range directly with your read-only repository tools: use the git_diff tool to see exactly what the commit range changed (including deletions and renames), and your read tools to verify the surrounding code. The commit range is the source of truth for this review.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Your read tools may be dedicated read and search tools, or a shell running in a read-only sandbox. If your only repository tool is that shell, use it to read files and search the tree (for example cat, sed -n, grep, ls); it cannot write, and you must not try to.
+Inspect the change with your read-only tools: call git_diff with the base and head commits named in this prompt (stat:true first for the changed-file overview, then per-path diffs), read the changed files in full, and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: lenient. Assume ordinary trust boundaries and block only on correctness failures and real, reachable bugs. Do not demand additional robustness, hardening, performance, or style work as a condition of acceptance.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Robustness or performance regressions introduced by the implementation are non_blocking unless they are a reachable correctness failure; use blocking severity only in that case.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Previous reviewer head was prevhead000. Focus especially on changes since that commit, while still considering the full current state.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+=== buildReviewerPrompt#accessMode=read-only-tool#earlierScopeChanges=absent#previousHead=present#reviewLevel=moderate ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+Review that commit range directly with your read-only repository tools: use the git_diff tool to see exactly what the commit range changed (including deletions and renames), and your read tools to verify the surrounding code. The commit range is the source of truth for this review.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Your read tools may be dedicated read and search tools, or a shell running in a read-only sandbox. If your only repository tool is that shell, use it to read files and search the tree (for example cat, sed -n, grep, ls); it cannot write, and you must not try to.
+Inspect the change with your read-only tools: call git_diff with the base and head commits named in this prompt (stat:true first for the changed-file overview, then per-path diffs), read the changed files in full, and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: moderate. Assume ordinary trust boundaries: internal run artifacts and other files this system writes for itself are not security boundaries. Block on correctness bugs and on failures reachable under normal use. Do not require defenses against an actor who could already subvert the system directly, for example by editing its files; a failure that needs such an actor is not reachable.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Previous reviewer head was prevhead000. Focus especially on changes since that commit, while still considering the full current state.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+=== buildReviewerPrompt#accessMode=read-only-tool#earlierScopeChanges=absent#previousHead=present#reviewLevel=strict ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+Review that commit range directly with your read-only repository tools: use the git_diff tool to see exactly what the commit range changed (including deletions and renames), and your read tools to verify the surrounding code. The commit range is the source of truth for this review.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Your read tools may be dedicated read and search tools, or a shell running in a read-only sandbox. If your only repository tool is that shell, use it to read files and search the tree (for example cat, sed -n, grep, ls); it cannot write, and you must not try to.
+Inspect the change with your read-only tools: call git_diff with the base and head commits named in this prompt (stat:true first for the changed-file overview, then per-path diffs), read the changed files in full, and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: strict. Assume adversarial trust boundaries: treat every input, file, and process the change can be reached from, including local processes and internal run artifacts, as a potential attacker. A hardening gap or a missing defense against a local or adversarial actor is a reachable failure under these boundaries and blocks.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Previous reviewer head was prevhead000. Focus especially on changes since that commit, while still considering the full current state.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+=== buildReviewerPrompt#accessMode=read-only-tool#earlierScopeChanges=present#previousHead=absent#reviewLevel=lenient ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+Review that commit range directly with your read-only repository tools: use the git_diff tool to see exactly what the commit range changed (including deletions and renames), and your read tools to verify the surrounding code. The commit range is the source of truth for this review.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Your read tools may be dedicated read and search tools, or a shell running in a read-only sandbox. If your only repository tool is that shell, use it to read files and search the tree (for example cat, sed -n, grep, ls); it cannot write, and you must not try to.
+Inspect the change with your read-only tools: call git_diff with the base and head commits named in this prompt (stat:true first for the changed-file overview, then per-path diffs), read the changed files in full, and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: lenient. Assume ordinary trust boundaries and block only on correctness failures and real, reachable bugs. Do not demand additional robustness, hardening, performance, or style work as a condition of acceptance.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Robustness or performance regressions introduced by the implementation are non_blocking unless they are a reachable correctness failure; use blocking severity only in that case.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+This is the first reviewer round for this scope.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+
+## Earlier-scope changes to files in this diff
+
+The files below were changed by an earlier accepted scope in this run and appear again in the current diff. Each entry shows what that earlier scope did to the file, so what the current scope alters is something you read here rather than something you have to remember.
+Check the current diff against each entry before accepting.
+
+### src/example.ts (scope 3, scope3base000..scope3final000)
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-older
++old
+
+=== buildReviewerPrompt#accessMode=read-only-tool#earlierScopeChanges=present#previousHead=absent#reviewLevel=moderate ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+Review that commit range directly with your read-only repository tools: use the git_diff tool to see exactly what the commit range changed (including deletions and renames), and your read tools to verify the surrounding code. The commit range is the source of truth for this review.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Your read tools may be dedicated read and search tools, or a shell running in a read-only sandbox. If your only repository tool is that shell, use it to read files and search the tree (for example cat, sed -n, grep, ls); it cannot write, and you must not try to.
+Inspect the change with your read-only tools: call git_diff with the base and head commits named in this prompt (stat:true first for the changed-file overview, then per-path diffs), read the changed files in full, and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: moderate. Assume ordinary trust boundaries: internal run artifacts and other files this system writes for itself are not security boundaries. Block on correctness bugs and on failures reachable under normal use. Do not require defenses against an actor who could already subvert the system directly, for example by editing its files; a failure that needs such an actor is not reachable.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+This is the first reviewer round for this scope.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+
+## Earlier-scope changes to files in this diff
+
+The files below were changed by an earlier accepted scope in this run and appear again in the current diff. Each entry shows what that earlier scope did to the file, so what the current scope alters is something you read here rather than something you have to remember.
+Check the current diff against each entry before accepting.
+
+### src/example.ts (scope 3, scope3base000..scope3final000)
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-older
++old
+
+=== buildReviewerPrompt#accessMode=read-only-tool#earlierScopeChanges=present#previousHead=absent#reviewLevel=strict ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+Review that commit range directly with your read-only repository tools: use the git_diff tool to see exactly what the commit range changed (including deletions and renames), and your read tools to verify the surrounding code. The commit range is the source of truth for this review.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Your read tools may be dedicated read and search tools, or a shell running in a read-only sandbox. If your only repository tool is that shell, use it to read files and search the tree (for example cat, sed -n, grep, ls); it cannot write, and you must not try to.
+Inspect the change with your read-only tools: call git_diff with the base and head commits named in this prompt (stat:true first for the changed-file overview, then per-path diffs), read the changed files in full, and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: strict. Assume adversarial trust boundaries: treat every input, file, and process the change can be reached from, including local processes and internal run artifacts, as a potential attacker. A hardening gap or a missing defense against a local or adversarial actor is a reachable failure under these boundaries and blocks.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+This is the first reviewer round for this scope.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+
+## Earlier-scope changes to files in this diff
+
+The files below were changed by an earlier accepted scope in this run and appear again in the current diff. Each entry shows what that earlier scope did to the file, so what the current scope alters is something you read here rather than something you have to remember.
+Check the current diff against each entry before accepting.
+
+### src/example.ts (scope 3, scope3base000..scope3final000)
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-older
++old
+
+=== buildReviewerPrompt#accessMode=read-only-tool#earlierScopeChanges=present#previousHead=present#reviewLevel=lenient ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+Review that commit range directly with your read-only repository tools: use the git_diff tool to see exactly what the commit range changed (including deletions and renames), and your read tools to verify the surrounding code. The commit range is the source of truth for this review.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Your read tools may be dedicated read and search tools, or a shell running in a read-only sandbox. If your only repository tool is that shell, use it to read files and search the tree (for example cat, sed -n, grep, ls); it cannot write, and you must not try to.
+Inspect the change with your read-only tools: call git_diff with the base and head commits named in this prompt (stat:true first for the changed-file overview, then per-path diffs), read the changed files in full, and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: lenient. Assume ordinary trust boundaries and block only on correctness failures and real, reachable bugs. Do not demand additional robustness, hardening, performance, or style work as a condition of acceptance.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Robustness or performance regressions introduced by the implementation are non_blocking unless they are a reachable correctness failure; use blocking severity only in that case.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Previous reviewer head was prevhead000. Focus especially on changes since that commit, while still considering the full current state.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+
+## Earlier-scope changes to files in this diff
+
+The files below were changed by an earlier accepted scope in this run and appear again in the current diff. Each entry shows what that earlier scope did to the file, so what the current scope alters is something you read here rather than something you have to remember.
+Check the current diff against each entry before accepting.
+
+### src/example.ts (scope 3, scope3base000..scope3final000)
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-older
++old
+
+=== buildReviewerPrompt#accessMode=read-only-tool#earlierScopeChanges=present#previousHead=present#reviewLevel=moderate ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+Review that commit range directly with your read-only repository tools: use the git_diff tool to see exactly what the commit range changed (including deletions and renames), and your read tools to verify the surrounding code. The commit range is the source of truth for this review.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Your read tools may be dedicated read and search tools, or a shell running in a read-only sandbox. If your only repository tool is that shell, use it to read files and search the tree (for example cat, sed -n, grep, ls); it cannot write, and you must not try to.
+Inspect the change with your read-only tools: call git_diff with the base and head commits named in this prompt (stat:true first for the changed-file overview, then per-path diffs), read the changed files in full, and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: moderate. Assume ordinary trust boundaries: internal run artifacts and other files this system writes for itself are not security boundaries. Block on correctness bugs and on failures reachable under normal use. Do not require defenses against an actor who could already subvert the system directly, for example by editing its files; a failure that needs such an actor is not reachable.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Previous reviewer head was prevhead000. Focus especially on changes since that commit, while still considering the full current state.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+
+## Earlier-scope changes to files in this diff
+
+The files below were changed by an earlier accepted scope in this run and appear again in the current diff. Each entry shows what that earlier scope did to the file, so what the current scope alters is something you read here rather than something you have to remember.
+Check the current diff against each entry before accepting.
+
+### src/example.ts (scope 3, scope3base000..scope3final000)
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-older
++old
+
+=== buildReviewerPrompt#accessMode=read-only-tool#earlierScopeChanges=present#previousHead=present#reviewLevel=strict ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+Review that commit range directly with your read-only repository tools: use the git_diff tool to see exactly what the commit range changed (including deletions and renames), and your read tools to verify the surrounding code. The commit range is the source of truth for this review.
+A diff shows only changed hunks; declarations such as imports, struct fields, or helpers may exist in unchanged parts of the file. Absence from the diff is not evidence of absence from the repository — open the affected file with your read tools and verify before claiming a missing import or missing declaration.
+Your read tools may be dedicated read and search tools, or a shell running in a read-only sandbox. If your only repository tool is that shell, use it to read files and search the tree (for example cat, sed -n, grep, ls); it cannot write, and you must not try to.
+Inspect the change with your read-only tools: call git_diff with the base and head commits named in this prompt (stat:true first for the changed-file overview, then per-path diffs), read the changed files in full, and search the tree for affected symbols and callers to verify claims.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: strict. Assume adversarial trust boundaries: treat every input, file, and process the change can be reached from, including local processes and internal run artifacts, as a potential attacker. A hardening gap or a missing defense against a local or adversarial actor is a reachable failure under these boundaries and blocks.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — reading them with your read tools — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, read the most relevant existing tests and affected code with your read tools and reason through the affected existing flows directly rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Previous reviewer head was prevhead000. Focus especially on changes since that commit, while still considering the full current state.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+
+## Earlier-scope changes to files in this diff
+
+The files below were changed by an earlier accepted scope in this run and appear again in the current diff. Each entry shows what that earlier scope did to the file, so what the current scope alters is something you read here rather than something you have to remember.
+Check the current diff against each entry before accepting.
+
+### src/example.ts (scope 3, scope3base000..scope3final000)
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-older
++old
+
+=== buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=absent#previousHead=absent#reviewLevel=lenient ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+Review that commit range directly with repository tools. The commit range is the source of truth for this review.
+Use git commands against the repository, for example: git diff base000..head000, git show --stat head000, and targeted path diffs or file reads for changed files.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Temporary verification scratch directory: /tmp/repo/.neal/runs/run-000/scratch/review
+Use that run-local scratch directory for temporary verification artifacts, copied tests, scratch builds, logs, and modified throwaway files.
+Do not create project-root scratch directories such as build_review/.
+Do not leave project-tree scratch files behind; keep scratch work under the run-local directory above.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: lenient. Assume ordinary trust boundaries and block only on correctness failures and real, reachable bugs. Do not demand additional robustness, hardening, performance, or style work as a condition of acceptance.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Robustness or performance regressions introduced by the implementation are non_blocking unless they are a reachable correctness failure; use blocking severity only in that case.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — running them when available — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, exercise or reason through the affected existing flows directly — run the most relevant existing tests or reproduce the reported behavior when practical — rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+This is the first reviewer round for this scope.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+=== buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=absent#previousHead=absent#reviewLevel=moderate ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+Review that commit range directly with repository tools. The commit range is the source of truth for this review.
+Use git commands against the repository, for example: git diff base000..head000, git show --stat head000, and targeted path diffs or file reads for changed files.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Temporary verification scratch directory: /tmp/repo/.neal/runs/run-000/scratch/review
+Use that run-local scratch directory for temporary verification artifacts, copied tests, scratch builds, logs, and modified throwaway files.
+Do not create project-root scratch directories such as build_review/.
+Do not leave project-tree scratch files behind; keep scratch work under the run-local directory above.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: moderate. Assume ordinary trust boundaries: internal run artifacts and other files this system writes for itself are not security boundaries. Block on correctness bugs and on failures reachable under normal use. Do not require defenses against an actor who could already subvert the system directly, for example by editing its files; a failure that needs such an actor is not reachable.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — running them when available — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, exercise or reason through the affected existing flows directly — run the most relevant existing tests or reproduce the reported behavior when practical — rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+This is the first reviewer round for this scope.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+=== buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=absent#previousHead=absent#reviewLevel=strict ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+Review that commit range directly with repository tools. The commit range is the source of truth for this review.
+Use git commands against the repository, for example: git diff base000..head000, git show --stat head000, and targeted path diffs or file reads for changed files.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Temporary verification scratch directory: /tmp/repo/.neal/runs/run-000/scratch/review
+Use that run-local scratch directory for temporary verification artifacts, copied tests, scratch builds, logs, and modified throwaway files.
+Do not create project-root scratch directories such as build_review/.
+Do not leave project-tree scratch files behind; keep scratch work under the run-local directory above.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: strict. Assume adversarial trust boundaries: treat every input, file, and process the change can be reached from, including local processes and internal run artifacts, as a potential attacker. A hardening gap or a missing defense against a local or adversarial actor is a reachable failure under these boundaries and blocks.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — running them when available — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, exercise or reason through the affected existing flows directly — run the most relevant existing tests or reproduce the reported behavior when practical — rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+This is the first reviewer round for this scope.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+=== buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=absent#previousHead=present#reviewLevel=lenient ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+Review that commit range directly with repository tools. The commit range is the source of truth for this review.
+Use git commands against the repository, for example: git diff base000..head000, git show --stat head000, and targeted path diffs or file reads for changed files.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Temporary verification scratch directory: /tmp/repo/.neal/runs/run-000/scratch/review
+Use that run-local scratch directory for temporary verification artifacts, copied tests, scratch builds, logs, and modified throwaway files.
+Do not create project-root scratch directories such as build_review/.
+Do not leave project-tree scratch files behind; keep scratch work under the run-local directory above.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: lenient. Assume ordinary trust boundaries and block only on correctness failures and real, reachable bugs. Do not demand additional robustness, hardening, performance, or style work as a condition of acceptance.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Robustness or performance regressions introduced by the implementation are non_blocking unless they are a reachable correctness failure; use blocking severity only in that case.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — running them when available — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, exercise or reason through the affected existing flows directly — run the most relevant existing tests or reproduce the reported behavior when practical — rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Previous reviewer head was prevhead000. Focus especially on changes since that commit, while still considering the full current state.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+=== buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=absent#previousHead=present#reviewLevel=moderate ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+Review that commit range directly with repository tools. The commit range is the source of truth for this review.
+Use git commands against the repository, for example: git diff base000..head000, git show --stat head000, and targeted path diffs or file reads for changed files.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Temporary verification scratch directory: /tmp/repo/.neal/runs/run-000/scratch/review
+Use that run-local scratch directory for temporary verification artifacts, copied tests, scratch builds, logs, and modified throwaway files.
+Do not create project-root scratch directories such as build_review/.
+Do not leave project-tree scratch files behind; keep scratch work under the run-local directory above.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: moderate. Assume ordinary trust boundaries: internal run artifacts and other files this system writes for itself are not security boundaries. Block on correctness bugs and on failures reachable under normal use. Do not require defenses against an actor who could already subvert the system directly, for example by editing its files; a failure that needs such an actor is not reachable.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — running them when available — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, exercise or reason through the affected existing flows directly — run the most relevant existing tests or reproduce the reported behavior when practical — rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Previous reviewer head was prevhead000. Focus especially on changes since that commit, while still considering the full current state.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+=== buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=absent#previousHead=present#reviewLevel=strict ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+Review that commit range directly with repository tools. The commit range is the source of truth for this review.
+Use git commands against the repository, for example: git diff base000..head000, git show --stat head000, and targeted path diffs or file reads for changed files.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Temporary verification scratch directory: /tmp/repo/.neal/runs/run-000/scratch/review
+Use that run-local scratch directory for temporary verification artifacts, copied tests, scratch builds, logs, and modified throwaway files.
+Do not create project-root scratch directories such as build_review/.
+Do not leave project-tree scratch files behind; keep scratch work under the run-local directory above.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: strict. Assume adversarial trust boundaries: treat every input, file, and process the change can be reached from, including local processes and internal run artifacts, as a potential attacker. A hardening gap or a missing defense against a local or adversarial actor is a reachable failure under these boundaries and blocks.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — running them when available — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, exercise or reason through the affected existing flows directly — run the most relevant existing tests or reproduce the reported behavior when practical — rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Previous reviewer head was prevhead000. Focus especially on changes since that commit, while still considering the full current state.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+=== buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=present#previousHead=absent#reviewLevel=lenient ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+Review that commit range directly with repository tools. The commit range is the source of truth for this review.
+Use git commands against the repository, for example: git diff base000..head000, git show --stat head000, and targeted path diffs or file reads for changed files.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Temporary verification scratch directory: /tmp/repo/.neal/runs/run-000/scratch/review
+Use that run-local scratch directory for temporary verification artifacts, copied tests, scratch builds, logs, and modified throwaway files.
+Do not create project-root scratch directories such as build_review/.
+Do not leave project-tree scratch files behind; keep scratch work under the run-local directory above.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: lenient. Assume ordinary trust boundaries and block only on correctness failures and real, reachable bugs. Do not demand additional robustness, hardening, performance, or style work as a condition of acceptance.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Robustness or performance regressions introduced by the implementation are non_blocking unless they are a reachable correctness failure; use blocking severity only in that case.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — running them when available — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, exercise or reason through the affected existing flows directly — run the most relevant existing tests or reproduce the reported behavior when practical — rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+This is the first reviewer round for this scope.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+
+## Earlier-scope changes to files in this diff
+
+The files below were changed by an earlier accepted scope in this run and appear again in the current diff. Each entry shows what that earlier scope did to the file, so what the current scope alters is something you read here rather than something you have to remember.
+Check the current diff against each entry before accepting.
+
+### src/example.ts (scope 3, scope3base000..scope3final000)
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-older
++old
+
+=== buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=present#previousHead=absent#reviewLevel=moderate ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+Review that commit range directly with repository tools. The commit range is the source of truth for this review.
+Use git commands against the repository, for example: git diff base000..head000, git show --stat head000, and targeted path diffs or file reads for changed files.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Temporary verification scratch directory: /tmp/repo/.neal/runs/run-000/scratch/review
+Use that run-local scratch directory for temporary verification artifacts, copied tests, scratch builds, logs, and modified throwaway files.
+Do not create project-root scratch directories such as build_review/.
+Do not leave project-tree scratch files behind; keep scratch work under the run-local directory above.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: moderate. Assume ordinary trust boundaries: internal run artifacts and other files this system writes for itself are not security boundaries. Block on correctness bugs and on failures reachable under normal use. Do not require defenses against an actor who could already subvert the system directly, for example by editing its files; a failure that needs such an actor is not reachable.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — running them when available — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, exercise or reason through the affected existing flows directly — run the most relevant existing tests or reproduce the reported behavior when practical — rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+This is the first reviewer round for this scope.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+
+## Earlier-scope changes to files in this diff
+
+The files below were changed by an earlier accepted scope in this run and appear again in the current diff. Each entry shows what that earlier scope did to the file, so what the current scope alters is something you read here rather than something you have to remember.
+Check the current diff against each entry before accepting.
+
+### src/example.ts (scope 3, scope3base000..scope3final000)
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-older
++old
+
+=== buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=present#previousHead=absent#reviewLevel=strict ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+Review that commit range directly with repository tools. The commit range is the source of truth for this review.
+Use git commands against the repository, for example: git diff base000..head000, git show --stat head000, and targeted path diffs or file reads for changed files.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Temporary verification scratch directory: /tmp/repo/.neal/runs/run-000/scratch/review
+Use that run-local scratch directory for temporary verification artifacts, copied tests, scratch builds, logs, and modified throwaway files.
+Do not create project-root scratch directories such as build_review/.
+Do not leave project-tree scratch files behind; keep scratch work under the run-local directory above.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: strict. Assume adversarial trust boundaries: treat every input, file, and process the change can be reached from, including local processes and internal run artifacts, as a potential attacker. A hardening gap or a missing defense against a local or adversarial actor is a reachable failure under these boundaries and blocks.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — running them when available — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, exercise or reason through the affected existing flows directly — run the most relevant existing tests or reproduce the reported behavior when practical — rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+This is the first reviewer round for this scope.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+
+## Earlier-scope changes to files in this diff
+
+The files below were changed by an earlier accepted scope in this run and appear again in the current diff. Each entry shows what that earlier scope did to the file, so what the current scope alters is something you read here rather than something you have to remember.
+Check the current diff against each entry before accepting.
+
+### src/example.ts (scope 3, scope3base000..scope3final000)
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-older
++old
+
+=== buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=present#previousHead=present#reviewLevel=lenient ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+Review that commit range directly with repository tools. The commit range is the source of truth for this review.
+Use git commands against the repository, for example: git diff base000..head000, git show --stat head000, and targeted path diffs or file reads for changed files.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Temporary verification scratch directory: /tmp/repo/.neal/runs/run-000/scratch/review
+Use that run-local scratch directory for temporary verification artifacts, copied tests, scratch builds, logs, and modified throwaway files.
+Do not create project-root scratch directories such as build_review/.
+Do not leave project-tree scratch files behind; keep scratch work under the run-local directory above.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: lenient. Assume ordinary trust boundaries and block only on correctness failures and real, reachable bugs. Do not demand additional robustness, hardening, performance, or style work as a condition of acceptance.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Robustness or performance regressions introduced by the implementation are non_blocking unless they are a reachable correctness failure; use blocking severity only in that case.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — running them when available — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, exercise or reason through the affected existing flows directly — run the most relevant existing tests or reproduce the reported behavior when practical — rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Previous reviewer head was prevhead000. Focus especially on changes since that commit, while still considering the full current state.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+
+## Earlier-scope changes to files in this diff
+
+The files below were changed by an earlier accepted scope in this run and appear again in the current diff. Each entry shows what that earlier scope did to the file, so what the current scope alters is something you read here rather than something you have to remember.
+Check the current diff against each entry before accepting.
+
+### src/example.ts (scope 3, scope3base000..scope3final000)
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-older
++old
+
+=== buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=present#previousHead=present#reviewLevel=moderate ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+Review that commit range directly with repository tools. The commit range is the source of truth for this review.
+Use git commands against the repository, for example: git diff base000..head000, git show --stat head000, and targeted path diffs or file reads for changed files.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Temporary verification scratch directory: /tmp/repo/.neal/runs/run-000/scratch/review
+Use that run-local scratch directory for temporary verification artifacts, copied tests, scratch builds, logs, and modified throwaway files.
+Do not create project-root scratch directories such as build_review/.
+Do not leave project-tree scratch files behind; keep scratch work under the run-local directory above.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: moderate. Assume ordinary trust boundaries: internal run artifacts and other files this system writes for itself are not security boundaries. Block on correctness bugs and on failures reachable under normal use. Do not require defenses against an actor who could already subvert the system directly, for example by editing its files; a failure that needs such an actor is not reachable.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — running them when available — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, exercise or reason through the affected existing flows directly — run the most relevant existing tests or reproduce the reported behavior when practical — rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Previous reviewer head was prevhead000. Focus especially on changes since that commit, while still considering the full current state.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+
+## Earlier-scope changes to files in this diff
+
+The files below were changed by an earlier accepted scope in this run and appear again in the current diff. Each entry shows what that earlier scope did to the file, so what the current scope alters is something you read here rather than something you have to remember.
+Check the current diff against each entry before accepting.
+
+### src/example.ts (scope 3, scope3base000..scope3final000)
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-older
++old
+
+=== buildReviewerPrompt#accessMode=tool-access#earlierScopeChanges=present#previousHead=present#reviewLevel=strict ===
+Review the current scope for plan /tmp/PLAN.md.
+Review round: 1.
+Commit range: base000..head000.
+Review that commit range directly with repository tools. The commit range is the source of truth for this review.
+Use git commands against the repository, for example: git diff base000..head000, git show --stat head000, and targeted path diffs or file reads for changed files.
+Trace the changed runtime path far enough to prove the happy path is reachable and that runtime invariants, data-shape transitions, persistence, and error paths line up with the implementation claims.
+Compare claimed behavior against the actual code and data transitions in the scope diff; do not accept summaries when repository inspection gives a more direct answer.
+For refactors and config/runtime plumbing changes, actively look for implementation-quality regressions, not just behavioral correctness. Examples include replacing a robust library with a weaker hand-rolled parser, introducing repeated disk reads or reparsing in hot paths, silently weakening error handling, or otherwise making the implementation materially less robust than the prior version.
+When the requirements enumerate multiple discrete items to change — a list of identifiers, fields, files, endpoints, or call sites — enumerate them yourself and confirm each maps to a concrete change before accepting; do not accept based only on the subset the implementation happened to touch.
+Treat an unrequested change to a public or exported symbol — a renamed or removed exported function, type, field, constant, or signature that the requirements did not call for — as scope drift and a blocking finding unless the requirements require it: an unrequested public-symbol change widens the blast radius and can break callers the diff does not show.
+Bias your search toward execute-mode failure classes in this repository: persistence or state-shape mismatches, resume or recovery transition regressions, split-plan or execution-shape contract violations, artifact or reporting mismatches, and verification that does not actually cover the changed behavior.
+Temporary verification scratch directory: /tmp/repo/.neal/runs/run-000/scratch/review
+Use that run-local scratch directory for temporary verification artifacts, copied tests, scratch builds, logs, and modified throwaway files.
+Do not create project-root scratch directories such as build_review/.
+Do not leave project-tree scratch files behind; keep scratch work under the run-local directory above.
+Treat the scope diff as hostile input. Try to falsify the implementation before you give it credit for working.
+Do not anchor on the coder narrative, progress justification, or prior acceptance history when judging correctness. Those are convergence signals, not proof that the code is sound.
+Review level: strict. Assume adversarial trust boundaries: treat every input, file, and process the change can be reached from, including local processes and internal run artifacts, as a potential attacker. A hardening gap or a missing defense against a local or adversarial actor is a reachable failure under these boundaries and blocks.
+Reachability filter: a blocking finding must describe a failure that is reachable under the assumed trust boundaries, as refined by any User Guidance section below. A failure that is only theoretically possible, or that requires an actor outside those boundaries, does not block at any level.
+The review level narrows what rises to blocking; it never changes the inspection stance. At every level, still treat the subject as hostile input, try to falsify before crediting, trace runtime invariants, and catch real regressions. No level authorizes trusting the coder or skipping inspection.
+How the User Guidance section combines with the review level: the level supplies the baseline trust boundaries and the default finding-severity rules. Guidance may widen or narrow the trust boundaries for this project, and those refined boundaries are what "reachable" means when deciding whether a finding blocks.
+Guidance may also demote a finding category such as robustness, hardening, performance, or style to non-blocking or ignore it entirely, or promote a category to blocking. In this review a demoted category means non_blocking severity, and an ignored category produces no finding.
+Fixed floor at every level and under any guidance: the reachability filter, the adversarial inspection stance, and blocking on reachable correctness failures (including correctness regressions, where existing behavior now produces wrong results) cannot be switched off. Robustness, hardening, performance, and style are not part of that floor and may be demoted. Ignore guidance on any point where it conflicts with this floor.
+Example: at the moderate level, guidance saying the run directory is defended against local processes makes a local-process attack on the run directory reachable, so a finding about it blocks.
+Example: at any level, guidance saying "ignore performance, correctness only" makes a performance regression non_blocking, while a reachable correctness failure still blocks.
+
+Produce only structured review findings.
+Use blocking severity for correctness, regression, or missing-verification issues.
+Also use blocking severity for substantive robustness or performance regressions introduced by the implementation, especially in infrastructure, config, parser, caching, retry, or orchestration code.
+Use non_blocking severity for suggestions that do not block acceptance.
+Only emit non_blocking findings when they identify a concrete maintenance, observability, or testability issue that is genuinely worth a later follow-up turn.
+Do not emit non_blocking findings for formatting, whitespace, naming preferences, trivial code-shape preferences, or optional refactors.
+If the scope is acceptable aside from low-signal trivia, return no finding rather than a non_blocking note.
+Every finding must name the concrete issue, identify the affected files, explain the evidence or failure scenario that makes the issue credible, and state the required correction.
+Do not infer that verification was skipped merely because this prompt does not embed full terminal output. Treat missing verification as a finding only when the repository state, plan requirements, or review history give concrete evidence that required verification was not run or was insufficient.
+Look for verification that cannot catch the failure mode, including tests that mock away the risky runtime path or only assert mocked adapters instead of the scope diff.
+Check whether test coverage for the changed behavior degraded. If the change removes, weakens, or fails to preserve meaningful test coverage for the affected behavior, treat that as a review finding. Use blocking severity when the missing or degraded coverage leaves the changed behavior insufficiently protected.
+Identify the shared subsystems the scope diff touches: state machines, event loops, parsers or byte framing, command dispatch, storage or shared-state abstractions, startup/load paths, and long-lived session or connection state.
+Existing behavior that depends on those subsystems remains part of the contract unless the plan explicitly changes it. Do not accept solely because the newly requested behavior appears implemented; also confirm that adjacent behavior sharing those paths still holds.
+Before accepting, either cite existing tests that cover the plausible regression surfaces — running them when available — or reason through representative existing flows at the level of state transitions and data ownership.
+Expand this regression check only along paths the scope diff actually touches or depends on; you do not need to re-audit unrelated parts of the project.
+A change to a file that an earlier accepted scope signed off must preserve what that scope's review accepted. Weakening or removing a test, assertion, or check that an earlier scope introduced is a blocking finding unless the plan explicitly calls for it.
+When the plan requires existing behavior to keep working, this review is not limited to newly changed lines. Apply an acceptance-surface test to any pre-existing crash, failure, flaky behavior, or anomaly reported in the coder narrative, progress justification, or review history instead of discounting it because it predates the scope diff.
+A pre-existing failure is inside the required acceptance surface when the plan explicitly requires the affected existing behavior to keep working, when the plan's stated verification fails because of it, or when the behavior the plan delivers cannot be exercised end-to-end without the failing path. Otherwise it is outside the surface.
+For a reported pre-existing failure inside the required surface, exercise or reason through the affected existing flows directly — run the most relevant existing tests or reproduce the reported behavior when practical — rather than relying on the coder's dismissal.
+An in-surface pre-existing failure that was neither fixed nor surfaced as a blocking concern is a blocking finding, and a dismissal without a concrete out-of-surface reason is a finding.
+Conversely, treat a fix for a pre-existing issue that fails the acceptance-surface test as scope drift rather than extra credit: flag it so the change stays bounded to the plan.
+Previous reviewer head was prevhead000. Focus especially on changes since that commit, while still considering the full current state.
+
+Commits in scope:
+head000 canonical render matrix
+
+Diff stat:
+ src/example.ts | 2 +-
+
+Changed files:
+src/example.ts
+
+Bounded current-run continuity context:
+# Reviewer Continuity Context
+
+Use this bounded Neal-owned context for continuity only. Inspect cited artifacts or repository state directly before making findings.
+
+## Run
+- id: run-000
+- plan: /tmp/PLAN.md
+- mode: execute
+- executionShape: multi_scope
+- phase: reviewer_scope
+- status: running
+- currentScope: 1
+
+## Completed Scopes
+- none
+- truncated: no
+
+## Findings
+- none
+- truncated: no
+
+## Inherited Plan-Review Debt
+- none
+
+## Final Completion
+- not applicable
+
+## Citations
+- RUN_STATE.json: .neal/runs/run-000/RUN_STATE.json
+- PLAN_PROGRESS.md: .neal/runs/run-000/PLAN_PROGRESS.md
+- plan-progress.json: .neal/runs/run-000/plan-progress.json
+- REVIEW.md: .neal/runs/run-000/REVIEW.md
+- RECOVERY.md: .neal/runs/run-000/RECOVERY.md
+- REVIEWER_CONTEXT.json: .neal/runs/run-000/REVIEWER_CONTEXT.json
+- REVIEWER_CONTEXT.md: .neal/runs/run-000/REVIEWER_CONTEXT.md
+
+The active parent objective for meaningful-progress evaluation is scope 1.
+You are the authority for meaningful-progress gating during this execute review pass, but perform that judgment after the adversarial correctness review above.
+Set `meaningfulProgressAction` to `accept` only when either this scope materially advances the active parent objective, or a top-level scope has no required new diff because prior accepted work already satisfies it and you find no issues with sufficient verification evidence.
+For top-level already-satisfied acceptance, use `accept`, not `advance_parent`, and name the prior accepted work plus the verification evidence in `meaningfulProgressRationale`.
+Set `meaningfulProgressAction` to `block_for_operator` when the objective genuinely cannot proceed without a decision only an operator can make.
+Set `meaningfulProgressAction` to `replace_plan` when the current execution shape should be replaced rather than retried.
+Set `meaningfulProgressAction` to `advance_parent` only when an active accepted derived plan has an empty current diff and prior accepted derived work already satisfies the parent objective.
+Do not use `block_for_operator` solely to ask Neal to retire an already-complete parent objective inside that derived-plan case; use `advance_parent` only for that narrow empty-derived-scope case.
+Keep `block_for_operator` for ambiguous already-satisfied claims, missing evidence, missing operator decisions, or unsafe parent-completion claims.
+A non-empty or uncertain current diff is the normal case, not a reason to escalate: handle it by accepting, requesting a bounded revision, or splitting the plan rather than choosing `block_for_operator`.
+Use `meaningfulProgressRationale` to explain the convergence judgment against the parent objective and recent accepted-scope history. Do not use it to restate correctness findings.
+
+Coder progress justification for this scope:
+{
+  "milestoneTargeted": "Deterministic milestone.",
+  "newEvidence": "Deterministic evidence.",
+  "whyNotRedundant": "Deterministic non-redundancy.",
+  "nextStepUnlocked": "Deterministic next step."
+}
+
+Recent accepted scope history for this parent objective:
+No accepted scopes yet.
+
+Prior review history is available at /tmp/REVIEW.md if you need earlier reviewer findings or coder responses, but review the current commit range directly.
+If prior review history or continuity context describes a finding as fixed, rejected, or deferred, do not reopen the same claim from that history alone.
+Before emitting a finding that resembles a prior fixed/rejected/deferred finding, inspect the current code or current diff and cite fresh current evidence showing the defect still exists.
+If current evidence is ambiguous for an already-addressed claim, do not use a blocking finding to force another coder loop; use meaningfulProgressAction=`block_for_operator` only when operator judgment is genuinely required.
+
+## Earlier-scope changes to files in this diff
+
+The files below were changed by an earlier accepted scope in this run and appear again in the current diff. Each entry shows what that earlier scope did to the file, so what the current scope alters is something you read here rather than something you have to remember.
+Check the current diff against each entry before accepting.
+
+### src/example.ts (scope 3, scope3base000..scope3final000)
+
+diff --git a/src/example.ts b/src/example.ts
+@@ -1 +1 @@
+-older
++old
+

--- a/test/inline-review-context.test.ts
+++ b/test/inline-review-context.test.ts
@@ -99,7 +99,8 @@ test('renderInlinedRangeDiffSection affirms read tools and presents the diff as 
   const rendered = renderInlinedRangeDiffSection({ rangeLabel: 'aaa..bbb', diff: '+added line' });
 
   assert.match(rendered, /## Inlined commit-range diff from Neal \(aaa\.\.bbb\)/);
-  assert.match(rendered, /You have read-only repository tools \(read and search, no shell\) but no commit-range diff tool/);
+  assert.match(rendered, /You have read-only repository access but no commit-range diff tool/);
+  assert.match(rendered, /a shell running in a read-only sandbox/);
   assert.match(rendered, /source of truth for exactly what this range changed/);
   assert.match(rendered, /\+added line/);
   // This is not the no-read framing: it must not deny all repository access.

--- a/test/prompt-render-integrity.test.ts
+++ b/test/prompt-render-integrity.test.ts
@@ -644,7 +644,7 @@ const EXPECTED_MODULE_SHAS: Record<(typeof MATRIX_BUILDER_MODULES)[number], stri
   'src/neal/prompts/specialized.ts': '396c46ab85aa4e41ef0bf5cbce5c84d0dd11210d07b25a4c58327fd615ca8683',
   'src/neal/agents/prompts.ts': 'c9b8b6bd135206ec8c7055aa887d65003490b8fdef95c3a662797018d01a667e',
   'src/neal/context/reviewer-context.ts': '7168f61b26ff2c9fb9fa67ce7c608f452722fcfc5187f8c346910264a4c00674',
-  'src/neal/context/inline-review-context.ts': 'e6b355023bc3736d0958a4fe253eab9e0ab6df321b21190c67e766623de6a029',
+  'src/neal/context/inline-review-context.ts': '707a75dec9712158b14c9b15ccac19491a6b0d3221089545b4b2c3431458bbe7',
 };
 
 function assertModuleShaMatches(relPath: (typeof MATRIX_BUILDER_MODULES)[number], expectedSha: string): void {


### PR DESCRIPTION
## Summary

Running `neal compat` with `gpt-6-astra` as the reviewer failed all four reviewer cells with `block_unresolved`: the model reported it had no repository read or search tools and that shell access was excluded by the review constraints, so it couldn't verify anything outside the inlined diff and blocked. Fable passed every coder and planner cell in the same run.

The cause is neal's wording, not the model. Every built-in reviewer declares `shell: false`, so all of them get the read-only doctrine, which tells the model to use its "read tools" and (in two places) says "no shell." That's true for Claude (Read and Grep) and for OpenRouter models (neal supplies read tools). It's false for Codex: its reviewer runs in the SDK's `read-only` sandbox, which is a policy on what the shell may do, not a tool allowlist, and the model reads by running `cat`, `grep`, and so on in that write-blocked shell. So the Codex reviewer was told "no shell, use your read tools" when the shell is its only read path. gpt-5.6-sol used the shell anyway and worked; Astra took the instruction literally and blocked. The run used codex-sdk 0.153.2, so it wasn't the SDK.

## Changes

- Read-only doctrine (`review-doctrine.ts`), the `neal review` prompt (`review-findings/prompts.ts`), and the inlined commit-range diff section (`context/inline-review-context.ts`): drop "no shell" and say that read access may be dedicated read and search tools or a shell in a read-only sandbox, and that a shell is for reading and searching only, never writing. Same sentence in all three places.
- `scope_reviewer` and `completion_reviewer` prompt specs bumped to v6 with new goldens and render SHAs; the `inline-review-context.ts` module SHA re-pinned.
- `inline-review-context.test.ts`: assert the new wording.

Keeps the read-only reviewer invariant intact: `shell: false` still means no shell for effect, and the sandbox still enforces it. Full suite green: typecheck, lint, 1784 tests, build, verify:package, plus the focused render-integrity test.

Next: re-run `neal compat --role reviewer` on this build to get Astra's real verdict, then record both models in `docs/compatible-models.md`.