### PR TITLE
Record claude-fable-5-1 and gpt-6-astra compat results

### DIFF
--- a/docs/compat.md
+++ b/docs/compat.md
@@ -53,6 +53,9 @@ neal compat [--model <slug>] [--role coder|reviewer|planner|all] [--reference op
 
 - `--role` (default `all`) selects which role(s) to test: `coder`, `reviewer`,
   `planner`, or `all`.
+- With no flags at all, every role runs on your configured provider and model,
+  which is how to verify a native slug (`openai-codex` or `anthropic-claude`);
+  `--model` always routes the candidate to `openai-compatible`.
 - `--model <slug>` runs the slug on the **`openai-compatible`** provider in the
   candidate role (provider forced to `openai-compatible`, any configured effort
   dropped, so the slug drives a clean OpenRouter call). When omitted, the

--- a/docs/compatible-models.md
+++ b/docs/compatible-models.md
@@ -156,6 +156,24 @@ don't support tool use.
 | `openai-codex` | supported | supported | supported |
 | `anthropic-claude` | supported | supported | supported |
 
+### Native model slugs run through the fixtures
+
+The adapters above are supported by construction. A row here means a specific
+slug has also been run through `neal compat`. To add one, put the slug in your
+config and run `neal compat` with no flags: every role then runs on your
+configured provider and model (`--model` always routes to `openai-compatible`,
+so it can't test a native slug). Cells are passed/total, same as the whitelist.
+
+| Slug | Provider | Coder | Reviewer | Planner | Run |
+| --- | --- | --- | --- | --- | --- |
+| `claude-fable-5-1` | `anthropic-claude` | 2/2 | not run | 1/1 | 2026-09-04 |
+| `gpt-6-astra` | `openai-codex` | not run | 2/2 pairs | not run | 2026-09-04 |
+
+`gpt-6-astra` as reviewer needs the read-only doctrine wording from #57. Before
+that, the doctrine told a Codex reviewer it had no shell, and Astra took it at
+its word and blocked every reviewer fixture for lack of a read tool; with the
+wording fixed it passed 4/4.
+
 ## Reproducing / extending
 
 ```


### PR DESCRIPTION
## Summary

Ran `neal compat` on the configured models (`claude-fable-5-1` as coder and planner, `gpt-6-astra` as reviewer) and recorded the results. Fable passed both coder fixtures and the planner fixture. Astra passed all four reviewer cells once the read-only doctrine wording was fixed in #57; before that it blocked every reviewer fixture because the doctrine told a Codex reviewer it had no shell, and Astra had no other way to read files.

## Changes

- `docs/compatible-models.md`: a "Native model slugs run through the fixtures" table under the native-adapters section, with both slugs, and a note on why Astra needs #57
- `docs/compat.md`: one bullet under Usage saying bare `neal compat` runs every role on your configured provider and model, which is how to verify a native slug (`--model` always routes to `openai-compatible`)

Docs only.