### PR TITLE
Prepare 0.6.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ dependency-update policy.
 
 ## [Unreleased]
 
+## [0.6.6] - 2026-09-04
+
 ### Fixed
 
 - The read-only reviewer doctrine told every reviewer it had read tools and no

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@navels/neal",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "A source-first multi-agent CLI for planning, executing, reviewing, and resuming scoped code changes.",
   "license": "MIT",
   "publishConfig": {


### PR DESCRIPTION
## Summary

Release prep for 0.6.6, a patch carrying the #57 reviewer wording fix.

## Changes

- `package.json` version 0.6.5 → 0.6.6
- `CHANGELOG.md`: move the Unreleased entry under `## [0.6.6] - 2026-09-04`