### PR TITLE
Prepare 0.6.7 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ dependency-update policy.
 
 ## [Unreleased]
 
+## [0.6.7] - 2026-09-08
+
+### Changed
+
+- Updated `@anthropic-ai/claude-agent-sdk` from `0.3.260` to `0.3.261` and `@openai/codex-sdk` from `0.153.2` to `0.153.4`. Re-qualified both native adapters with `neal compat`; no behavior change.
+
 ## [0.6.6] - 2026-09-04
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@navels/neal",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "description": "A source-first multi-agent CLI for planning, executing, reviewing, and resuming scoped code changes.",
   "license": "MIT",
   "publishConfig": {


### PR DESCRIPTION
## Summary

Release prep for 0.6.7, a patch release covering the dependency bumps from #53.

## Changes

- Bump `package.json.version` to 0.6.7
- Add the 0.6.7 changelog section:

- Updated `@anthropic-ai/claude-agent-sdk` from `0.3.260` to `0.3.261` and `@openai/codex-sdk` from `0.153.2` to `0.153.4`. Re-qualified both native adapters with `neal compat`; no behavior change.

All release gates pass locally via scripts/release-sdk-bump.sh.