### PR TITLE
Skip the live smoke when a PR changes nothing it exercises

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -41,6 +41,9 @@ jobs:
   smoke:
     name: neal compat smoke (openai-compatible / OpenRouter)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     # A wedged provider call otherwise runs to GitHub's 6-hour default; the
     # whole 3-attempt loop normally finishes in ~20 minutes (#56).
     timeout-minutes: 45
@@ -63,28 +66,49 @@ jobs:
       # below override per-role, but provider detection wants a default.
       OPENAI_COMPATIBLE_MODEL: ${{ inputs.model || 'minimax/minimax-m2.5' }}
     steps:
-      - name: Guard — skip when no OpenRouter key or on native-SDK PRs
+      - name: Guard — run only when something the smoke exercises changed
         id: guard
-        # HEAD_REF via env, never inlined into the script: a branch name is
-        # untrusted input.
+        # The smoke drives the AI-SDK tier through openai-compatible, plus the
+        # compat command and its fixtures. A PR that changes none of that (a
+        # version bump, or a bump to the native SDK pins, which the smoke never
+        # drives; qualify-sdk.sh covers those) has nothing for it to test, and
+        # it costs ~20 minutes, so skip it. Decided from the PR's actual diff
+        # via the API, never from the branch name. Anything unclear runs.
         env:
-          HEAD_REF: ${{ github.head_ref }}
+          GH_TOKEN: ${{ github.token }}
+          EVENT: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           if [ -z "${OPENROUTER_API_KEY}" ]; then
             echo "No OPENROUTER_API_KEY secret present; skipping live smoke."
             echo "run=false" >> "$GITHUB_OUTPUT"
-          elif [ "${HEAD_REF}" = "renovate/native-agentic-sdks" ]; then
-            # The smoke drives openai-compatible/OpenRouter and never exercises the
-            # native @openai/codex-sdk / @anthropic-ai/claude-agent-sdk adapters
-            # (no subscription auth in CI). Those are qualified locally by
-            # scripts/qualify-sdk.sh, so running the smoke here tests nothing that
-            # changed. Skip it (the job still reports green so a required-check
-            # gate stays satisfied).
-            echo "Native-SDK PR; the smoke does not exercise the native adapters (qualify-sdk.sh does). Skipping."
-            echo "run=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+          if [ "$EVENT" != "pull_request" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          files="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" --paginate --jq '.[].filename')"
+          if printf '%s\n' "$files" | grep -qE '^(src/neal/commands/compat\.ts|examples/compat/|scripts/smoke-aggregate\.mjs|\.github/workflows/smoke\.yml)'; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if printf '%s\n' "$files" | grep -qx 'package.json'; then
+            residual="$(diff \
+              <(gh api "repos/${GITHUB_REPOSITORY}/contents/package.json?ref=${BASE_SHA}" -H 'Accept: application/vnd.github.raw+json') \
+              <(gh api "repos/${GITHUB_REPOSITORY}/contents/package.json?ref=${HEAD_SHA}" -H 'Accept: application/vnd.github.raw+json') \
+              | grep -E '^[<>]' | grep -vE '"version":|"@openai/codex-sdk":|"@anthropic-ai/claude-agent-sdk":' || true)"
+            if [ -n "$residual" ]; then
+              echo "run=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            echo "package.json changed only the version and/or the native SDK pins; the smoke exercises neither. Skipping."
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "run=true" >> "$GITHUB_OUTPUT"
 
       - name: Check out repository
         if: steps.guard.outputs.run == 'true'

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -10,7 +10,7 @@ Grouped so at most a handful of dependency PRs are ever open at once:
 | Bucket | Contents | Cadence | Update posture |
 | --- | --- | --- | --- |
 | **Weekly non-major** | everything except the native SDKs (minor/patch/pin/digest) | weekly, one grouped PR | auto-merge after CI and the live smoke pass, subject to a 3-day soak |
-| **Native SDKs** | `@openai/codex-sdk` and `@anthropic-ai/claude-agent-sdk`, both exact-pinned. `ai`, `@ai-sdk/openai-compatible`, and `zod` also stay exact-pinned. | one grouped PR, opened after the 3-day soak instead of waiting for the weekly schedule | qualify on a subscription-authenticated machine with `scripts/qualify-sdk.sh`. Never auto-merge. Skip the CI smoke because it does not exercise the native adapters. |
+| **Native SDKs** | `@openai/codex-sdk` and `@anthropic-ai/claude-agent-sdk`, both exact-pinned. `ai`, `@ai-sdk/openai-compatible`, and `zod` also stay exact-pinned. | one grouped PR, opened after the 3-day soak instead of waiting for the weekly schedule | qualify on a subscription-authenticated machine with `scripts/qualify-sdk.sh`. Never auto-merge. The CI smoke skips itself on these PRs because it does not exercise the native adapters. |
 | **Library majors** | every npm major except the native SDKs (`typescript`, `@types/node`, `ai`, `@ai-sdk/openai-compatible`, `zod`, etc.) | monthly, one grouped PR | review manually because some need code changes |
 | **GitHub Actions majors** | `actions/checkout`, `actions/setup-node`, `actions/upload-artifact`, etc. | monthly, one grouped PR separate from library majors | review and merge on green CI. Do not auto-merge because a major action bump can still change behavior. |
 
@@ -19,7 +19,7 @@ tool-calling, structured output, or sandbox behavior. That breaks neal's loop
 **without** breaking compilation. And CI can't behaviorally exercise the
 native adapters: their auth is subscription-based and lives only on a
 maintainer's machine. Everything else is behaviorally exercised in CI: the
-live smoke runs on every package.json/lockfile PR, so the weekly grouped PR
+live smoke runs on package.json/lockfile PRs that change something it exercises, so the weekly grouped PR
 is gated on it as a whole.
 
 ## The update flow
@@ -31,7 +31,7 @@ is gated on it as a whole.
 2. **Verify (automatic).** CI (`.github/workflows/ci.yml`) runs typecheck + lint
    + unit tests + package verification on Node 24.18.0, which catches
    **API-shape / contract** breaks. The live smoke
-   (`.github/workflows/smoke.yml`) runs on every package.json / lockfile PR: a
+   (`.github/workflows/smoke.yml`) runs on package.json / lockfile PRs that change something it exercises (a version bump or a native-SDK pin bump skips it): a
    real `neal compat` run against a cheap OpenRouter model through
    `openai-compatible`, catching **behavioral** breaks in the AI-SDK tier. The
    weekly non-major PR auto-merges when both are green.


### PR DESCRIPTION
## Summary

The live smoke runs on every `package.json` PR, which includes every release-prep PR and every native-SDK bump. Neither changes anything the smoke tests (it drives the AI-SDK tier through `openai-compatible`; the native adapters can't run in CI and are qualified by `qualify-sdk.sh`), and it costs about 20 minutes each time. The old guard only skipped Renovate's SDK branch by name, so the manual bumps from `bump-native-sdks.sh` and every release prep still ran it.

The guard now decides from the PR's actual diff: run if the PR touches the compat command, its fixtures, the aggregate script, or the workflow itself, or if `package.json` changed anything other than the `version` field and the two native SDK pins; otherwise skip. A lockfile-only change still runs, since resolved AI-SDK dependencies may have moved. Anything unclear runs. The branch-name special case is gone.

Checked against merged history: #61 and #43 (weekly buckets) run; #60 and #55 (release prep) and #52, #53, #45, #42 (SDK bumps) skip.

## Changes

- `.github/workflows/smoke.yml`: content-based guard via the GitHub API, job-level `contents: read` / `pull-requests: read` permissions for it, branch-name check removed
- `docs/maintenance.md`: describe when the smoke runs

This PR changes `smoke.yml`, so the new guard takes the "run" path here and the smoke runs on this PR; that's the end-to-end check of the guard itself.